### PR TITLE
refactor: commentService

### DIFF
--- a/backend/project2/src/main/java/com/team8/project2/domain/comment/dto/CommentDto.java
+++ b/backend/project2/src/main/java/com/team8/project2/domain/comment/dto/CommentDto.java
@@ -40,4 +40,5 @@ public class CommentDto {
                 .modifiedAt(modifiedAt)
                 .build();
     }
+
 }

--- a/backend/project2/src/main/java/com/team8/project2/domain/comment/service/CommentService.java
+++ b/backend/project2/src/main/java/com/team8/project2/domain/comment/service/CommentService.java
@@ -3,6 +3,8 @@ package com.team8.project2.domain.comment.service;
 import com.team8.project2.domain.comment.dto.CommentDto;
 import com.team8.project2.domain.comment.entity.Comment;
 import com.team8.project2.domain.comment.repository.CommentRepository;
+import com.team8.project2.domain.curation.entity.Curation;
+import com.team8.project2.domain.curation.repository.CurationRepository;
 import com.team8.project2.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,9 +19,21 @@ import java.util.stream.Collectors;
 public class CommentService {
 
     private final CommentRepository commentRepository;
+    private final CurationRepository curationRepository;
 
     public CommentDto createComment(CommentDto commentDto) {
-        Comment comment = commentDto.toEntity();
+        // curationId가 Long 타입인지 확인
+        if (commentDto.getCurationId() == null) {
+            throw new ServiceException("CURATION_ID_NULL", "큐레이션 ID가 제공되지 않았습니다.");
+        }
+
+        // curationId를 이용해 Curation 조회
+        Curation curation = curationRepository.findById(commentDto.getCurationId())
+                .orElseThrow(() -> new ServiceException("CURATION_NOT_FOUND",
+                        "해당 큐레이션을 찾을 수 없습니다. (id: " + commentDto.getCurationId() + ")"));
+
+        // Curation 객체를 사용해 Comment 생성
+        Comment comment = commentDto.toEntity(curation);
         Comment savedComment = commentRepository.save(comment);
         return CommentDto.fromEntity(savedComment);
     }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

ID 타입을 String에서 Long으로 변경하는 과정에서 발생한 문제를 해결하였습니다.
기존 코드에서 id 및 curationId를 String으로 처리하려던 흔적이 남아 있어, 
이를 Long 타입으로 통일하는 과정에서 타입 불일치로 인한 오류가 발생하였습니다.

## 주요 변경 사항
- **CommentDto 수정**
curationId를 Long 타입으로 유지하고, toEntity() 변환 로직을 수정하여 Curation 객체를 직접 참조할 수 있도록 개선.

- **CommentService 수정**
curationId가 null인 경우 예외를 발생시키고, CurationRepository를 이용해 curationId에 해당하는 Curation을 조회하도록 변경.
toEntity(curation)을 호출할 때 curationId를 Curation 객체로 변환하여 타입 불일치 문제 해결.

- **Comment 엔티티 수정**
curationId 대신 Curation 객체를 @ManyToOne으로 참조하도록 유지하여 올바른 관계를 설정.

- **CommentRepository 수정**
findByCurationId(Long curationId) → findByCuration_Id(Long curationId)로 변경하여 JPA 네이밍 규칙에 맞게 수정.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
