### PR TITLE
Refactor/#29 playlist unit test

### DIFF
--- a/backend/.idea/modules/project2.iml
+++ b/backend/.idea/modules/project2.iml
@@ -14,6 +14,15 @@
       <excludeFolder url="file://$MODULE_DIR$/../../project2/.gradle" />
       <excludeFolder url="file://$MODULE_DIR$/../../project2/build" />
     </content>
+    <content url="file://$MODULE_DIR$/../../project2">
+      <excludeFolder url="file://$MODULE_DIR$/../../project2/.gradle" />
+      <excludeFolder url="file://$MODULE_DIR$/../../project2/build" />
+    </content>
+    <content url="file://$MODULE_DIR$/../../project2" />
+    <content url="file://$MODULE_DIR$/../../project2">
+      <excludeFolder url="file://$MODULE_DIR$/../../project2/.gradle" />
+      <excludeFolder url="file://$MODULE_DIR$/../../project2/build" />
+    </content>
     <content url="file://$MODULE_DIR$/../../project2" />
     <content url="file://$MODULE_DIR$/../../project2">
       <excludeFolder url="file://$MODULE_DIR$/../../project2/.gradle" />

--- a/backend/.idea/modules/project2.main.iml
+++ b/backend/.idea/modules/project2.main.iml
@@ -34,6 +34,18 @@
       <sourceFolder url="file://$MODULE_DIR$/../../project2/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/../../project2/src/main/resources" type="java-resource" />
     </content>
+    <content url="file://$MODULE_DIR$/../../project2/src/main">
+      <sourceFolder url="file://$MODULE_DIR$/../../project2/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../../project2/src/main/resources" type="java-resource" />
+    </content>
+    <content url="file://$MODULE_DIR$/../../project2/src/main">
+      <sourceFolder url="file://$MODULE_DIR$/../../project2/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../../project2/src/main/resources" type="java-resource" />
+    </content>
+    <content url="file://$MODULE_DIR$/../../project2/src/main">
+      <sourceFolder url="file://$MODULE_DIR$/../../project2/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../../project2/src/main/resources" type="java-resource" />
+    </content>
     <orderEntry type="jdk" jdkName="graalvm-ce-21" jdkType="JavaSDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" scope="PROVIDED" name="Gradle: org.projectlombok:lombok:1.18.36" level="project" />

--- a/backend/.idea/modules/project2.test.iml
+++ b/backend/.idea/modules/project2.test.iml
@@ -28,6 +28,15 @@
     <content url="file://$MODULE_DIR$/../../project2/src/test">
       <sourceFolder url="file://$MODULE_DIR$/../../project2/src/test/java" isTestSource="true" />
     </content>
+    <content url="file://$MODULE_DIR$/../../project2/src/test">
+      <sourceFolder url="file://$MODULE_DIR$/../../project2/src/test/java" isTestSource="true" />
+    </content>
+    <content url="file://$MODULE_DIR$/../../project2/src/test">
+      <sourceFolder url="file://$MODULE_DIR$/../../project2/src/test/java" isTestSource="true" />
+    </content>
+    <content url="file://$MODULE_DIR$/../../project2/src/test">
+      <sourceFolder url="file://$MODULE_DIR$/../../project2/src/test/java" isTestSource="true" />
+    </content>
     <orderEntry type="jdk" jdkName="graalvm-ce-21" jdkType="JavaSDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="project2.main" />

--- a/backend/project2/src/main/java/com/team8/project2/domain/playlist/entity/Playlist.java
+++ b/backend/project2/src/main/java/com/team8/project2/domain/playlist/entity/Playlist.java
@@ -3,6 +3,7 @@ package com.team8.project2.domain.playlist.entity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -17,10 +18,13 @@ public class Playlist {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false) // 🔹 NULL 허용 안 함
     private String title;
 
+    @Column(nullable = false) // 🔹 NULL 허용 안 함
     private String description;
 
     @OneToMany(mappedBy = "playlist", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<PlaylistItem> items;
+    @Builder.Default
+    private List<PlaylistItem> items = new ArrayList<>(); // 🔹 NULL 방지 (빈 리스트로 초기화)
 }

--- a/backend/project2/src/main/java/com/team8/project2/domain/playlist/entity/PlaylistItem.java
+++ b/backend/project2/src/main/java/com/team8/project2/domain/playlist/entity/PlaylistItem.java
@@ -16,10 +16,13 @@ public class PlaylistItem {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false) // 🔹 NULL 허용 안 함
     private Long itemId;
+
+    @Column(nullable = false) // 🔹 NULL 허용 안 함
     private String itemType;
 
     @ManyToOne
-    @JoinColumn(name = "playlist_id")
+    @JoinColumn(name = "playlist_id", nullable = false) // 🔹 NULL 허용 안 함 (반드시 Playlist와 연결)
     private Playlist playlist;
 }

--- a/backend/project2/src/test/java/com/team8/project2/domain/playlist/controller/ApiV1PlaylistControllerTest.java
+++ b/backend/project2/src/test/java/com/team8/project2/domain/playlist/controller/ApiV1PlaylistControllerTest.java
@@ -4,6 +4,7 @@ import com.team8.project2.domain.playlist.dto.PlaylistCreateDto;
 import com.team8.project2.domain.playlist.dto.PlaylistDto;
 import com.team8.project2.domain.playlist.service.PlaylistService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,7 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ExtendWith(MockitoExtension.class)
 class ApiV1PlaylistControllerTest {
 
-    private final MockMvc mockMvc;
+    private MockMvc mockMvc;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @InjectMocks
@@ -30,8 +31,9 @@ class ApiV1PlaylistControllerTest {
     @Mock
     private PlaylistService playlistService;
 
-    ApiV1PlaylistControllerTest() {
-        this.mockMvc = MockMvcBuilders.standaloneSetup(playlistController).build();
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(playlistController).build(); // 🔹 여기서 초기화!
     }
 
     @Test


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
## 엔티티의 필드 nullable = false 설정 및 테스트 코드 안정성 개선을 수행.
**엔티티 컬럼의 nullable = false 설정**
- Playlist, PlaylistItem 엔티티의 필드(title, description, itemId, itemType)에 @Column(nullable = false) 추가.
- 데이터베이스 레벨에서 NULL 값 입력을 방지하여 데이터 무결성 강화.
- @OneToMany 관계의 List<PlaylistItem> 필드는 @Builder.Default를 활용해 빈 리스트로 초기화.
- 테스트 코드 수정 및 안정성 향상

**PlaylistServiceTest 및 ApiV1PlaylistControllerTest에서 발생하는 NullPointerException 방지.**
- MockMvc 초기화 시 @BeforeEach에서 mockMvc = MockMvcBuilders.standaloneSetup(controller).build(); 적용.
- PlaylistDto.fromEntity()에서 Collections.emptyList() 반환하여 null 방지.
- @DisplayName을 추가하여 테스트 코드의 가독성 및 명확성 개선.
## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
