### PR TITLE
Feat/#49 메인페이지 정렬, 메타데이터, 좋아요 기능 추가

### DIFF
--- a/backend/project2/build.gradle
+++ b/backend/project2/build.gradle
@@ -46,6 +46,9 @@ dependencies {
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// 외부 링크의 메타 데이터 추출 라이브러리 Jsoup
+	implementation 'org.jsoup:jsoup:1.15.4'
 }
 
 tasks.named('test') {

--- a/backend/project2/src/main/java/com/team8/project2/domain/curation/curation/controller/ApiV1CurationController.java
+++ b/backend/project2/src/main/java/com/team8/project2/domain/curation/curation/controller/ApiV1CurationController.java
@@ -71,6 +71,6 @@ public class ApiV1CurationController {
     @PostMapping("/{id}")
     public RsData<Void> likeCuration(@PathVariable Long id) {
         curationService.likeCuration(id);
-        return new RsData<>("200-1", "글에 좋아요를 했습니다.");
+        return new RsData<>("200-1", "글에 좋아요를 했습니다.", null);
     }
 }

--- a/backend/project2/src/main/java/com/team8/project2/domain/curation/curation/controller/ApiV1CurationController.java
+++ b/backend/project2/src/main/java/com/team8/project2/domain/curation/curation/controller/ApiV1CurationController.java
@@ -8,6 +8,7 @@ import com.team8.project2.domain.curation.curation.service.CurationService;
 import com.team8.project2.domain.curation.tag.service.TagService;
 import com.team8.project2.global.dto.RsData;
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -50,6 +51,7 @@ public class ApiV1CurationController {
     }
 
     // 전체 글 조회 및 검색
+    @Transactional(readOnly = true)
     @GetMapping
     public RsData<List<CurationResDto>> searchCuration(
             @RequestParam(required = false) List<String> tags,

--- a/backend/project2/src/main/java/com/team8/project2/domain/curation/curation/dto/CurationResDto.java
+++ b/backend/project2/src/main/java/com/team8/project2/domain/curation/curation/dto/CurationResDto.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 @Getter
 @Setter
 public class CurationResDto {
+    private Long id;
     private String title;
     private String content;
     private List<LinkResDto> urls;
@@ -38,6 +39,7 @@ public class CurationResDto {
     }
 
     public CurationResDto(Curation curation) {
+        this.id = curation.getId();
         this.title = curation.getTitle();
         this.content = curation.getContent();
         this.urls = curation.getCurationLinks().stream()

--- a/backend/project2/src/main/java/com/team8/project2/domain/curation/curation/dto/CurationResDto.java
+++ b/backend/project2/src/main/java/com/team8/project2/domain/curation/curation/dto/CurationResDto.java
@@ -6,6 +6,7 @@ import com.team8.project2.domain.link.entity.Link;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -17,6 +18,9 @@ public class CurationResDto {
     private String content;
     private List<LinkResDto> urls;
     private List<TagResDto> tags;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+    private Long likeCount;
 
     @Getter
     @Setter
@@ -48,5 +52,8 @@ public class CurationResDto {
         this.tags = curation.getTags().stream()
                 .map(tag -> new TagResDto(tag.getTag()))
                 .collect(Collectors.toList());
+        this.createdAt = curation.getCreatedAt();
+        this.modifiedAt = curation.getModifiedAt();
+        this.likeCount = curation.getLikeCount();
     }
 }

--- a/backend/project2/src/main/java/com/team8/project2/domain/link/controller/ApiV1LinkController.java
+++ b/backend/project2/src/main/java/com/team8/project2/domain/link/controller/ApiV1LinkController.java
@@ -1,6 +1,7 @@
 package com.team8.project2.domain.link.controller;
 
 import com.team8.project2.domain.link.dto.LinkReqDTO;
+import com.team8.project2.domain.link.dto.LinkResDTO;
 import com.team8.project2.domain.link.entity.Link;
 import com.team8.project2.domain.link.service.LinkService;
 import com.team8.project2.global.dto.RsData;
@@ -34,5 +35,13 @@ public class ApiV1LinkController {
     public RsData<Void> deleteLink(@PathVariable Long linkId) {
         linkService.deleteLink(linkId);
         return new RsData<>("204-1", "링크가 성공적으로 삭제되었습니다.");
+    }
+
+    // 메타 데이터 추출 API
+    @PostMapping("/preview")
+    public RsData<LinkResDTO> getLinkPreview(@RequestBody @Valid LinkReqDTO linkDTO)  {
+        System.out.println("linkDTO.getUrl() = " + linkDTO.getUrl());
+        LinkResDTO linkResDTO = linkService.getLinkMetaData(linkDTO.getUrl());
+        return new RsData<>("200","메타 데이터가 성공적으로 추출되었습니다.",linkResDTO);
     }
 }

--- a/backend/project2/src/main/java/com/team8/project2/domain/link/dto/LinkResDTO.java
+++ b/backend/project2/src/main/java/com/team8/project2/domain/link/dto/LinkResDTO.java
@@ -1,0 +1,13 @@
+package com.team8.project2.domain.link.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LinkResDTO {
+    private String url;
+    private String title;
+    private String description;
+    private String image;
+}

--- a/backend/project2/src/main/java/com/team8/project2/domain/link/service/LinkService.java
+++ b/backend/project2/src/main/java/com/team8/project2/domain/link/service/LinkService.java
@@ -1,11 +1,17 @@
 package com.team8.project2.domain.link.service;
 
+import com.team8.project2.domain.link.dto.LinkResDTO;
 import com.team8.project2.domain.link.entity.Link;
 import com.team8.project2.domain.link.repository.LinkRepository;
 import com.team8.project2.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
 
 @Service
 @RequiredArgsConstructor
@@ -44,5 +50,37 @@ public class LinkService {
     public Link getLink(String url) {
         return linkRepository.findByUrl(url)
                 .orElseGet(() -> linkRepository.save(Link.builder().url(url).build()));
+    }
+
+    // 링크 메타 데이터 추출
+    @Transactional
+    public LinkResDTO getLinkMetaData(String url) {
+        try {
+            // Jsoup을 사용하여 URL의 HTML을 파싱
+            Document doc = Jsoup.connect(url).get();
+
+            // 메타 데이터 추출
+            String title = getMetaTagContent(doc, "og:title");
+            String description = getMetaTagContent(doc, "og:description");
+            String image = getMetaTagContent(doc, "og:image");
+
+            // DTO에 메타 데이터 설정
+            LinkResDTO linkResDTO = new LinkResDTO();
+            linkResDTO.setUrl(url);
+            linkResDTO.setTitle(title);
+            linkResDTO.setDescription(description);
+            linkResDTO.setImage(image);
+
+            return linkResDTO;
+        } catch (IOException e) {
+            // 예외 발생 시 커스텀 예외 던지기
+            throw new ServiceException("500-1", "메타 데이터 추출 중 오류가 발생했습니다.");
+        }
+    }
+
+    // 메타 태그 내용 추출 유틸리티 함수
+    private String getMetaTagContent(Document doc, String property) {
+        Element metaTag = doc.select("meta[property=" + property + "]").first();
+        return metaTag != null ? metaTag.attr("content") : "";
     }
 }

--- a/backend/project2/src/main/java/com/team8/project2/global/security/SecurityConfig.java
+++ b/backend/project2/src/main/java/com/team8/project2/global/security/SecurityConfig.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.header.writers.frameoptions.XFrameOptionsHeaderWriter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -33,11 +34,19 @@ public class SecurityConfig {
 				.requestMatchers(HttpMethod.PUT, "/api/v1/curation/**").permitAll()
 				.requestMatchers(HttpMethod.POST, "/api/v1/curation/**").permitAll()
 				.requestMatchers(HttpMethod.DELETE, "/api/v1/curation/**").permitAll()
+				.requestMatchers(HttpMethod.POST, "/api/v1/link/**").permitAll()
 				.requestMatchers("/api/v1/playlists/**").authenticated()
+
+				// 🔹 h2-console 접근 허용
+				.requestMatchers(HttpMethod.GET, "/h2-console/**").permitAll()
+				.requestMatchers(HttpMethod.POST, "/h2-console/**").permitAll()
 
 				// 🔹 그 외 모든 요청 인증 필요
 				.anyRequest().authenticated()
 			)
+			.headers((headers) -> headers
+					.addHeaderWriter(new XFrameOptionsHeaderWriter(
+							XFrameOptionsHeaderWriter.XFrameOptionsMode.SAMEORIGIN)))
 
 			// ✅ CSRF 비활성화 (API 사용을 위해 필수)
 			.csrf(csrf -> csrf.disable());

--- a/frontend/project2/app/components/post-list.tsx
+++ b/frontend/project2/app/components/post-list.tsx
@@ -1,188 +1,103 @@
+'use client'
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { Heart, MessageSquare, Bookmark, Share2 } from "lucide-react";
 
+// Curation 데이터 인터페이스 정의
+interface Curation {
+  id: number;
+  title: string;
+  content: string;
+  createdBy: string;
+  createdAt: string;
+}
+
 export default function PostList() {
+  const [curations, setCurations] = useState<Curation[]>([]);
+
+  useEffect(() => {
+    // 로컬호스트에서 데이터를 받아오는 API 호출
+    fetch("http://localhost:8080/api/v1/curation")
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error("Network response was not ok");
+        }
+        return response.json();
+      })
+      .then((data) => {
+        // API 응답에서 data.data를 확인하고 상태 업데이트
+        if (data && data.data) {
+          setCurations(data.data);
+        } else {
+          console.error("No data found in the response");
+        }
+      })
+      .catch((error) => console.error("Error fetching curations:", error));
+  }, []);
+
   return (
     <div className="space-y-6 pt-4">
-      {/* First Post */}
-      <div className="space-y-4 border-b pb-6">
-        <div className="flex items-center space-x-2">
-          <Image
-            src="/placeholder.svg?height=40&width=40"
-            alt="김지민"
-            width={40}
-            height={40}
-            className="rounded-full"
-          />
-          <div>
-            <p className="font-medium">김지민</p>
-            <p className="text-xs text-gray-500">1시간 전</p>
-          </div>
-        </div>
+      {curations.length === 0 ? (
+        <p>글이 없습니다.</p>
+      ) : (
+        curations.map((curation) => (
+          <div key={curation.id} className="space-y-4 border-b pb-6">
+            <div className="flex items-center space-x-2">
+              <div>
+                <p className="font-medium">{curation.createdBy}</p>
+                <p className="text-xs text-gray-500">{curation.createdAt}</p>
+              </div>
+            </div>
 
-        <div>
-          <Link href="/post/1" className="group">
-            <h2 className="text-xl font-bold group-hover:text-blue-600">
-              ChatGPT를 활용한 생산성 향상 가이드
-            </h2>
-          </Link>
-          <p className="mt-2 text-gray-600">
-            ChatGPT의 최신 업데이트와 함께 새롭게 활용할 수 있는 생산성 향상
-            방법들을 소개합니다. 특히 업무 자동화, 코드 리뷰, 문서 요약 등
-            다양한 영역에서 ChatGPT를 활용하는 실질적인 방법들을 정리했습니다.
-            화려한 장점뿐만 아니게 몇 가지 주의할 점...
-          </p>
-          <button className="mt-2 text-sm font-medium text-blue-600">
-            더보기
-          </button>
-        </div>
-
-        <div className="mt-4 rounded-lg border p-4">
-          <div className="flex items-center space-x-3">
-            <Image
-              src="/placeholder.svg?height=48&width=48"
-              alt="ChatGPT"
-              width={48}
-              height={48}
-              className="rounded"
-            />
             <div>
-              <h3 className="font-medium">ChatGPT - OpenAI</h3>
-              <p className="text-sm text-gray-600">
-                AI 기반 대화형 언어 모델로, 다양한 작업을 지원하고 생산성을
-                향상시킬 수 있습니다.
+              <Link href={`/post/${curation.id}`} className="group">
+                <h2 className="text-xl font-bold group-hover:text-blue-600">
+                  {curation.title}
+                </h2>
+              </Link>
+              <p className="mt-2 text-gray-600">
+                {curation.content.length > 100
+                  ? `${curation.content.substring(0, 100)}...`
+                  : curation.content}
               </p>
-              <p className="text-xs text-gray-500">openai.com</p>
+              <button className="mt-2 text-sm font-medium text-blue-600">
+                더보기
+              </button>
+            </div>
+
+            <div className="mt-4 rounded-lg border p-4">
+              <div className="flex items-center space-x-3">
+                <div>
+                  <h3 className="font-medium">Content Link</h3>
+                  <p className="text-sm text-gray-600">Description</p>
+                </div>
+              </div>
+            </div>
+
+            <div className="flex items-center justify-between">
+              <div className="flex items-center space-x-4">
+                <button className="flex items-center space-x-1 text-sm text-gray-500">
+                  <Heart className="h-4 w-4" />
+                  <span>42</span>
+                </button>
+                <button className="flex items-center space-x-1 text-sm text-gray-500">
+                  <MessageSquare className="h-4 w-4" />
+                  <span>12</span>
+                </button>
+              </div>
+              <div className="flex space-x-2">
+                <button>
+                  <Bookmark className="h-4 w-4 text-gray-500" />
+                </button>
+                <button>
+                  <Share2 className="h-4 w-4 text-gray-500" />
+                </button>
+              </div>
             </div>
           </div>
-        </div>
-
-        <p className="text-sm text-gray-600">
-          ChatGPT를 활용해 워크플로 최적화 요약을 자동화하는 방법이
-          인상적이었습니다. 특히 올싱 녹취를 텍스트로 변환한 후 핵심 포인트만
-          추출하는 프롬프트 활용법이요.
-        </p>
-
-        <div className="flex space-x-2">
-          <span className="rounded-full bg-blue-100 px-2 py-1 text-xs font-medium text-blue-800">
-            #AI
-          </span>
-          <span className="rounded-full bg-green-100 px-2 py-1 text-xs font-medium text-green-800">
-            #생산성
-          </span>
-        </div>
-
-        <div className="flex items-center justify-between">
-          <div className="flex items-center space-x-4">
-            <button className="flex items-center space-x-1 text-sm text-gray-500">
-              <Heart className="h-4 w-4" />
-              <span>42</span>
-            </button>
-            <button className="flex items-center space-x-1 text-sm text-gray-500">
-              <MessageSquare className="h-4 w-4" />
-              <span>12</span>
-            </button>
-          </div>
-          <div className="flex space-x-2">
-            <button>
-              <Bookmark className="h-4 w-4 text-gray-500" />
-            </button>
-            <button>
-              <Share2 className="h-4 w-4 text-gray-500" />
-            </button>
-          </div>
-        </div>
-      </div>
-
-      {/* Second Post */}
-      <div className="space-y-4">
-        <div className="flex items-center space-x-2">
-          <Image
-            src="/placeholder.svg?height=40&width=40"
-            alt="박민수"
-            width={40}
-            height={40}
-            className="rounded-full"
-          />
-          <div>
-            <p className="font-medium">박민수</p>
-            <p className="text-xs text-gray-500">3시간 전</p>
-          </div>
-        </div>
-
-        <div>
-          <Link href="/post/2" className="group">
-            <h2 className="text-xl font-bold group-hover:text-blue-600">
-              React 18의 새로운 기능 살펴보기
-            </h2>
-          </Link>
-          <p className="mt-2 text-gray-600">
-            React 18의 주요 변경사항과 새로운 기능들을 자세히 살펴봅니다.
-            Concurrent Rendering의 개념과 실제 구현 방법, Suspense와 Transition
-            API의 활용, 자동 배치 처리의 이점 등을 다룹니다. 특히 대규모
-            애플리케이션에서의 성능 최적화...
-          </p>
-          <button className="mt-2 text-sm font-medium text-blue-600">
-            더보기
-          </button>
-        </div>
-
-        <div className="mt-4 rounded-lg border p-4">
-          <div className="flex items-center space-x-3">
-            <Image
-              src="/placeholder.svg?height=48&width=48"
-              alt="React"
-              width={48}
-              height={48}
-              className="rounded"
-            />
-            <div>
-              <h3 className="font-medium">React 18 Documentation</h3>
-              <p className="text-sm text-gray-600">
-                React 18의 새로운 기능과 Concurrent 렌더링에 대한 공식
-                문서입니다.
-              </p>
-              <p className="text-xs text-gray-500">reactjs.org</p>
-            </div>
-          </div>
-        </div>
-
-        <p className="text-sm text-gray-600">
-          React 18에서 도입된 Concurrent 렌더링의 실제 활용 사례를 정리했습니다.
-          Suspense와 함께 사용하면 UX가 확실히 개선되는 것 같네요.
-        </p>
-
-        <div className="flex space-x-2">
-          <span className="rounded-full bg-purple-100 px-2 py-1 text-xs font-medium text-purple-800">
-            #개발
-          </span>
-          <span className="rounded-full bg-yellow-100 px-2 py-1 text-xs font-medium text-yellow-800">
-            #React
-          </span>
-        </div>
-
-        <div className="flex items-center justify-between">
-          <div className="flex items-center space-x-4">
-            <button className="flex items-center space-x-1 text-sm text-gray-500">
-              <Heart className="h-4 w-4" />
-              <span>35</span>
-            </button>
-            <button className="flex items-center space-x-1 text-sm text-gray-500">
-              <MessageSquare className="h-4 w-4" />
-              <span>8</span>
-            </button>
-          </div>
-          <div className="flex space-x-2">
-            <button>
-              <Bookmark className="h-4 w-4 text-gray-500" />
-            </button>
-            <button>
-              <Share2 className="h-4 w-4 text-gray-500" />
-            </button>
-          </div>
-        </div>
-      </div>
+        ))
+      )}
     </div>
   );
 }

--- a/frontend/project2/app/components/post-list.tsx
+++ b/frontend/project2/app/components/post-list.tsx
@@ -1,7 +1,6 @@
-'use client'
+"use client";
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import Image from "next/image";
 import { Heart, MessageSquare, Bookmark, Share2 } from "lucide-react";
 
 // Curation 데이터 인터페이스 정의
@@ -11,93 +10,222 @@ interface Curation {
   content: string;
   createdBy: string;
   createdAt: string;
+  modifiedAt: string;
+  likeCount: number;
+  urls: { url: string }[]; // URLs 배열 추가
+  tags: { name: string }[];
 }
+
+// Link 메타 데이터 인터페이스 정의
+interface LinkMetaData {
+  url: string;
+  title: string;
+  description: string;
+  image: string;
+}
+
+type SortOrder = "LATEST" | "LIKECOUNT";
 
 export default function PostList() {
   const [curations, setCurations] = useState<Curation[]>([]);
+  const [sortOrder, setSortOrder] = useState<SortOrder>("LATEST"); // 기본값: 최신순
+  const [loading, setLoading] = useState<boolean>(false);
+  const [linkMetaDataList, setLinkMetaDataList] = useState<{ [key: number]: LinkMetaData[] }>({}); // 각 큐레이션에 대한 메타 데이터 상태 (배열로 수정)
 
+  // API 요청 함수
+  const fetchCurations = async (order: SortOrder) => {
+    setLoading(true);
+    try {
+      const response = await fetch(`http://localhost:8080/api/v1/curation?order=${order}`);
+      if (!response.ok) {
+        throw new Error("Network response was not ok");
+      }
+      const data = await response.json();
+      if (data && data.data) {
+        setCurations(data.data);
+      } else {
+        console.error("No data found in the response");
+      }
+    } catch (error) {
+      console.error("Error fetching curations:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // 메타 데이터 추출 함수
+  const fetchLinkMetaData = async (url: string, curationId: number) => {
+    try {
+      const response = await fetch(`http://localhost:8080/api/v1/link/preview`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ "url" : url }), // body에 JSON 형태로 URL을 전달
+      });
+  
+      if (!response.ok) {
+        throw new Error("Failed to fetch link metadata");
+      }
+      
+      const data = await response.json();
+      setLinkMetaDataList((prev) => ({
+        ...prev,
+        [curationId]: [...(prev[curationId] || []), data.data], // 메타 데이터 배열로 업데이트
+      })); // 메타 데이터 상태 업데이트
+    } catch (error) {
+      console.error("Error fetching link metadata:", error);
+    }
+  };
+
+  // 좋아요 추가 API 호출 함수
+  const likeCuration = async (id: number) => {
+    try {
+      const response = await fetch(`http://localhost:8080/api/v1/curation/${id}`, {
+        method: 'POST', // POST 요청으로 좋아요 추가
+      });
+      if (!response.ok) {
+        throw new Error("Failed to like the post");
+      }
+
+      // 좋아요를 추가한 후, 데이터를 다시 불러와서 화면 갱신
+      fetchCurations(sortOrder);
+    } catch (error) {
+      console.error("Error liking the post:", error);
+    }
+  };
+
+  // 정렬 변경 시 API 호출
   useEffect(() => {
-    // 로컬호스트에서 데이터를 받아오는 API 호출
-    fetch("http://localhost:8080/api/v1/curation")
-      .then((response) => {
-        if (!response.ok) {
-          throw new Error("Network response was not ok");
-        }
-        return response.json();
-      })
-      .then((data) => {
-        // API 응답에서 data.data를 확인하고 상태 업데이트
-        if (data && data.data) {
-          setCurations(data.data);
-        } else {
-          console.error("No data found in the response");
-        }
-      })
-      .catch((error) => console.error("Error fetching curations:", error));
-  }, []);
+    fetchCurations(sortOrder);
+  }, [sortOrder]);
+
+  // 큐레이션마다 메타 데이터 추출
+  useEffect(() => {
+    curations.forEach((curation) => {
+      if (curation.urls.length > 0) {
+        curation.urls.forEach(urlObj => {
+          fetchLinkMetaData(urlObj.url, curation.id); // 각 URL에 대해 메타 데이터 추출
+        });
+      }
+    });
+  }, [curations]);
+
+  // 날짜 형식화 함수
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    const hours = String(date.getHours()).padStart(2, "0");
+    const minutes = String(date.getMinutes()).padStart(2, "0");
+    return `${year}년 ${month}월 ${day}일 ${hours}:${minutes}`;
+  };
 
   return (
-    <div className="space-y-6 pt-4">
-      {curations.length === 0 ? (
-        <p>글이 없습니다.</p>
-      ) : (
-        curations.map((curation) => (
-          <div key={curation.id} className="space-y-4 border-b pb-6">
-            <div className="flex items-center space-x-2">
-              <div>
-                <p className="font-medium">{curation.createdBy}</p>
-                <p className="text-xs text-gray-500">{curation.createdAt}</p>
-              </div>
-            </div>
+    <>
+      {/* 정렬 버튼 */}
+      <div className="flex items-center justify-between mb-4">
+        <div className="inline-flex h-9 items-center justify-center rounded-lg bg-gray-100 p-1 text-gray-500">
+          <button
+            className={`inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium shadow ${
+              sortOrder === "LATEST" ? "bg-white text-black" : "text-gray-500"
+            }`}
+            onClick={() => setSortOrder("LATEST")}
+          >
+            최신순
+          </button>
+          <button
+            className={`inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium shadow ${
+              sortOrder === "LIKECOUNT" ? "bg-white text-black" : "text-gray-500"
+            }`}
+            onClick={() => setSortOrder("LIKECOUNT")}
+          >
+            좋아요순
+          </button>
+        </div>
+      </div>
 
-            <div>
-              <Link href={`/post/${curation.id}`} className="group">
-                <h2 className="text-xl font-bold group-hover:text-blue-600">
-                  {curation.title}
-                </h2>
-              </Link>
-              <p className="mt-2 text-gray-600">
-                {curation.content.length > 100
-                  ? `${curation.content.substring(0, 100)}...`
-                  : curation.content}
+      {/* 로딩 상태 표시 */}
+      {loading ? <p>데이터를 불러오는 중...</p> : null}
+
+      {/* 게시글 목록 */}
+      <div className="space-y-6 pt-4">
+        {curations.length === 0 ? (
+          <p>글이 없습니다.</p>
+        ) : (
+          curations.map((curation) => (
+            <div key={curation.id} className="space-y-4 border-b pb-6">
+              <div className="flex items-center space-x-2">
+              <p className="text-xs text-gray-500">
+                {Math.floor(new Date(curation.modifiedAt).getTime() / 1000) !== Math.floor(new Date(curation.createdAt).getTime() / 1000)
+                  ? `수정된 날짜 : ${formatDate(curation.modifiedAt)}`
+                  : `작성된 날짜 : ${formatDate(curation.createdAt)}`}
               </p>
-              <button className="mt-2 text-sm font-medium text-blue-600">
-                더보기
-              </button>
-            </div>
+              </div>
 
-            <div className="mt-4 rounded-lg border p-4">
-              <div className="flex items-center space-x-3">
-                <div>
-                  <h3 className="font-medium">Content Link</h3>
-                  <p className="text-sm text-gray-600">Description</p>
+              <div>
+                <Link href={`/post/${curation.id}`} className="group">
+                  <h2 className="text-xl font-bold group-hover:text-blue-600">
+                    {curation.title}
+                  </h2>
+                </Link>
+                <p className="mt-2 text-gray-600">
+                  {curation.content.length > 100
+                    ? `${curation.content.substring(0, 100)}...`
+                    : curation.content}
+                </p>
+                <button className="mt-2 text-sm font-medium text-blue-600">더보기</button>
+              </div>
+
+              {/* 메타 데이터 카드 */}
+              {linkMetaDataList[curation.id]?.map((metaData, index) => (
+                <Link key={index} href={metaData.url} passHref>
+                  <div className="mt-4 rounded-lg border p-4 cursor-pointer">
+                    <div className="flex items-center space-x-3">
+                      <img
+                        src={metaData.image}
+                        alt="Preview"
+                        className="h-12 w-12 rounded-lg"
+                      />
+                      <div>
+                        <h3 className="font-medium">{metaData.title}</h3>
+                        <p className="text-sm text-gray-600">
+                          {metaData.description}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </Link>
+              ))}
+
+              <div className="flex items-center justify-between">
+                <div className="flex items-center space-x-4">
+                  <button
+                    className="flex items-center space-x-1 text-sm text-gray-500"
+                    onClick={() => likeCuration(curation.id)} // 좋아요 버튼 클릭 시 likeCuration 호출
+                  >
+                    <Heart className="h-4 w-4" />
+                    <span>{curation.likeCount}</span>
+                  </button>
+                  <button className="flex items-center space-x-1 text-sm text-gray-500">
+                    <MessageSquare className="h-4 w-4" />
+                    <span>12</span>
+                  </button>
+                </div>
+                <div className="flex space-x-2">
+                  <button>
+                    <Bookmark className="h-4 w-4 text-gray-500" />
+                  </button>
+                  <button>
+                    <Share2 className="h-4 w-4 text-gray-500" />
+                  </button>
                 </div>
               </div>
             </div>
-
-            <div className="flex items-center justify-between">
-              <div className="flex items-center space-x-4">
-                <button className="flex items-center space-x-1 text-sm text-gray-500">
-                  <Heart className="h-4 w-4" />
-                  <span>42</span>
-                </button>
-                <button className="flex items-center space-x-1 text-sm text-gray-500">
-                  <MessageSquare className="h-4 w-4" />
-                  <span>12</span>
-                </button>
-              </div>
-              <div className="flex space-x-2">
-                <button>
-                  <Bookmark className="h-4 w-4 text-gray-500" />
-                </button>
-                <button>
-                  <Share2 className="h-4 w-4 text-gray-500" />
-                </button>
-              </div>
-            </div>
-          </div>
-        ))
-      )}
-    </div>
+          ))
+        )}
+      </div>
+    </>
   );
 }

--- a/frontend/project2/app/page.tsx
+++ b/frontend/project2/app/page.tsx
@@ -9,22 +9,6 @@ export default function Home() {
         <LeftSidebar />
       </div>
       <div className="col-span-7">
-        <div className="flex items-center justify-between mb-4">
-          <div className="inline-flex h-9 items-center justify-center rounded-lg bg-gray-100 p-1 text-gray-500">
-            <button className="inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium bg-white text-black shadow">
-              최신순
-            </button>
-            <button className="inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium">
-              인기순
-            </button>
-          </div>
-          <div className="flex items-center">
-            <span className="text-sm text-gray-500">필터</span>
-            <select className="ml-2 h-8 rounded-md border bg-white px-2 text-sm">
-              <option>전체</option>
-            </select>
-          </div>
-        </div>
         <PostList />
       </div>
       <div className="col-span-3">


### PR DESCRIPTION
## 개요
메인 페이지 큐레이션 최신순, 좋아요 순 정렬 추가
메인 페이지 큐레이션 링크 메타 데이터 받아와서 표시
메인 페이지 좋아요 기능 추가
-단순 db 1 증가 후에 멤버랑 연계해서 중복으로 올릴 수 없게 해야됨

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

Closes #49 