### PR TITLE
Feat/#74 특정 큐레이터의 큐레이션 조회

### DIFF
--- a/backend/project2/src/main/java/com/team8/project2/domain/curation/curation/controller/ApiV1CurationController.java
+++ b/backend/project2/src/main/java/com/team8/project2/domain/curation/curation/controller/ApiV1CurationController.java
@@ -98,9 +98,10 @@ public class ApiV1CurationController {
             @RequestParam(required = false) List<String> tags,
             @RequestParam(required = false) String title,
             @RequestParam(required = false) String content,
+            @RequestParam(required = false) String author,
             @RequestParam(required = false, defaultValue = "LATEST") SearchOrder order
     ) {
-        List<CurationResDto> result = curationService.searchCurations(tags, title, content, order)
+        List<CurationResDto> result = curationService.searchCurations(tags, title, content, author, order)
                 .stream()
                 .map(CurationResDto::new)
                 .collect(Collectors.toUnmodifiableList());

--- a/backend/project2/src/main/java/com/team8/project2/domain/curation/curation/repository/CurationRepository.java
+++ b/backend/project2/src/main/java/com/team8/project2/domain/curation/curation/repository/CurationRepository.java
@@ -16,55 +16,61 @@ import java.util.List;
 @Repository
 public interface CurationRepository extends JpaRepository<Curation, Long> {
 
-    /**
-     * 필터 조건을 기반으로 큐레이션을 검색하는 메서드입니다.
-     * 제목, 내용, 태그를 기준으로 검색하며, 정렬 방식(최신순, 오래된순, 좋아요순)을 지원합니다.
-     *
-     * @param tags 태그 목록 (선택적)
-     * @param title 제목 검색어 (선택적)
-     * @param content 내용 검색어 (선택적)
-     * @param searchOrder 정렬 기준 (LATEST, OLDEST, LIKECOUNT)
-     * @return 검색된 큐레이션 목록
-     */
-    @Query("SELECT c FROM Curation c " +
-            "LEFT JOIN c.tags ct " +
-            "LEFT JOIN ct.tag t " +
-            "WHERE (:title IS NULL OR c.title LIKE %:title%) " +
-            "AND (:content IS NULL OR c.content LIKE %:content%) " +
-            "AND (:tags IS NULL OR t.name IN :tags) " +
-            "GROUP BY c.id " +
-            "HAVING COUNT(DISTINCT t.name) = :tagsSize " +
-            "ORDER BY " +
-            "CASE WHEN :searchOrder = 'LATEST' THEN c.createdAt END DESC, " +
-            "CASE WHEN :searchOrder = 'OLDEST' THEN c.createdAt END ASC, " +
-            "CASE WHEN :searchOrder = 'LIKECOUNT' THEN c.likeCount END DESC")
-    List<Curation> searchByFilters(@Param("tags") List<String> tags,
-                                   @Param("tagsSize") int tagsSize,
-                                   @Param("title") String title,
-                                   @Param("content") String content,
-                                   @Param("searchOrder") String searchOrder);
+	/**
+	 * 필터 조건을 기반으로 큐레이션을 검색하는 메서드입니다.
+	 * 제목, 내용, 태그를 기준으로 검색하며, 정렬 방식(최신순, 오래된순, 좋아요순)을 지원합니다.
+	 *
+	 * @param tags 태그 목록 (선택적)
+	 * @param title 제목 검색어 (선택적)
+	 * @param content 내용 검색어 (선택적)
+	 * @param searchOrder 정렬 기준 (LATEST, OLDEST, LIKECOUNT)
+	 * @return 검색된 큐레이션 목록
+	 */
+	@Query("SELECT c FROM Curation c " +
+		"LEFT JOIN c.tags ct " +
+		"LEFT JOIN ct.tag t " +
+		"WHERE (:title IS NULL OR c.title LIKE %:title%) " +
+		"AND (:content IS NULL OR c.content LIKE %:content%) " +
+		"AND (:author IS NULL OR c.member.username LIKE %:author%) " +
+		"AND (:tags IS NULL OR t.name IN :tags) " +
+		"GROUP BY c.id " +
+		"HAVING COUNT(DISTINCT t.name) = :tagsSize " +
+		"ORDER BY " +
+		"CASE WHEN :searchOrder = 'LATEST' THEN c.createdAt END DESC, " +
+		"CASE WHEN :searchOrder = 'OLDEST' THEN c.createdAt END ASC, " +
+		"CASE WHEN :searchOrder = 'LIKECOUNT' THEN c.likeCount END DESC")
+	List<Curation> searchByFilters(@Param("tags") List<String> tags,
+		@Param("tagsSize") int tagsSize,
+		@Param("title") String title,
+		@Param("content") String content,
+		@Param("author") String author,
+		@Param("searchOrder") String searchOrder);
 
-    /**
-     * 태그가 비어있는 경우 필터를 적용하지 않고 큐레이션을 검색하는 메서드입니다.
-     *
-     * @param tags 태그 목록 (선택적)
-     * @param title 제목 검색어 (선택적)
-     * @param content 내용 검색어 (선택적)
-     * @param searchOrder 정렬 기준 (LATEST, OLDEST, LIKECOUNT)
-     * @return 검색된 큐레이션 목록
-     */
-    @Query("SELECT c FROM Curation c " +
-            "LEFT JOIN c.tags ct " +
-            "LEFT JOIN ct.tag t " +
-            "WHERE (:title IS NULL OR c.title LIKE %:title%) " +
-            "AND (:content IS NULL OR c.content LIKE %:content%) " +
-            "AND (:tags IS NULL OR t.name IN :tags) " +
-            "ORDER BY " +
-            "CASE WHEN :searchOrder = 'LATEST' THEN c.createdAt END DESC, " +
-            "CASE WHEN :searchOrder = 'OLDEST' THEN c.createdAt END ASC, " +
-            "CASE WHEN :searchOrder = 'LIKECOUNT' THEN c.likeCount END DESC")
-    List<Curation> searchByFiltersWithoutTags(@Param("tags") List<String> tags,
-                                              @Param("title") String title,
-                                              @Param("content") String content,
-                                              @Param("searchOrder") String searchOrder);
+
+	/**
+	 * 태그가 비어있는 경우 필터를 적용하지 않고 큐레이션을 검색하는 메서드입니다.
+	 *
+	 * @param tags 태그 목록 (선택적)
+	 * @param title 제목 검색어 (선택적)
+	 * @param content 내용 검색어 (선택적)
+	 * @param searchOrder 정렬 기준 (LATEST, OLDEST, LIKECOUNT)
+	 * @return 검색된 큐레이션 목록
+	 */
+	@Query("SELECT c FROM Curation c " +
+		"LEFT JOIN c.tags ct " +
+		"LEFT JOIN ct.tag t " +
+		"WHERE (:title IS NULL OR c.title LIKE %:title%) " +
+		"AND (:content IS NULL OR c.content LIKE %:content%) " +
+		"AND (:author IS NULL OR c.member.username LIKE %:author%) " +
+		"AND (:tags IS NULL OR t.name IN :tags) " +
+		"ORDER BY " +
+		"CASE WHEN :searchOrder = 'LATEST' THEN c.createdAt END DESC, " +
+		"CASE WHEN :searchOrder = 'OLDEST' THEN c.createdAt END ASC, " +
+		"CASE WHEN :searchOrder = 'LIKECOUNT' THEN c.likeCount END DESC")
+	List<Curation> searchByFiltersWithoutTags(@Param("tags") List<String> tags,
+		@Param("title") String title,
+		@Param("content") String content,
+		@Param("author") String author,
+		@Param("searchOrder") String searchOrder);
+
 }

--- a/backend/project2/src/main/java/com/team8/project2/domain/curation/curation/service/CurationService.java
+++ b/backend/project2/src/main/java/com/team8/project2/domain/curation/curation/service/CurationService.java
@@ -152,13 +152,13 @@ public class CurationService {
      * @param order 정렬 기준
      * @return 검색된 큐레이션 목록
      */
-    public List<Curation> searchCurations(List<String> tags, String title, String content, SearchOrder order) {
+    public List<Curation> searchCurations(List<String> tags, String title, String content, String author, SearchOrder order) {
         if (tags == null || tags.isEmpty()) {
             // 태그가 없을 경우 필터 없이 검색
-            return curationRepository.searchByFiltersWithoutTags(tags, title, content, order.name());
+            return curationRepository.searchByFiltersWithoutTags(tags, title, content, author, order.name());
         } else {
             // 태그가 있을 경우 태그 필터 적용
-            return curationRepository.searchByFilters(tags, tags.size(), title, content, order.name());
+            return curationRepository.searchByFilters(tags, tags.size(), title, content, author, order.name());
         }
     }
 

--- a/backend/project2/src/test/java/com/team8/project2/domain/curation/controller/ApiV1CurationControllerTest.java
+++ b/backend/project2/src/test/java/com/team8/project2/domain/curation/controller/ApiV1CurationControllerTest.java
@@ -23,6 +23,9 @@ import com.team8.project2.domain.curation.curation.repository.CurationRepository
 import com.team8.project2.domain.curation.curation.service.CurationService;
 import com.team8.project2.domain.curation.tag.dto.TagReqDto;
 import com.team8.project2.domain.link.dto.LinkReqDTO;
+import com.team8.project2.domain.member.entity.Member;
+import com.team8.project2.domain.member.entity.RoleEnum;
+import com.team8.project2.domain.member.repository.MemberRepository;
 
 @Transactional
 @ActiveProfiles("test")
@@ -39,6 +42,8 @@ public class ApiV1CurationControllerTest {
 	private CurationReqDTO curationReqDTO;
 	@Autowired
 	private CurationRepository curationRepository;
+	@Autowired
+	private MemberRepository memberRepository;
 
 	@BeforeEach
 	void setUp() {
@@ -64,8 +69,7 @@ public class ApiV1CurationControllerTest {
 	// 글 생성 테스트
 	@Test
 	void createCuration() throws Exception {
-		mockMvc.perform(post("/api/v1/curation")
-				.contentType("application/json")
+		mockMvc.perform(post("/api/v1/curation").contentType("application/json")
 				.content(new ObjectMapper().writeValueAsString(curationReqDTO)))
 			.andExpect(status().isCreated())
 			.andExpect(jsonPath("$.code").value("201-1"))
@@ -80,15 +84,10 @@ public class ApiV1CurationControllerTest {
 	@Test
 	void updateCuration() throws Exception {
 		// 테스트용 데이터 저장
-		Curation savedCuration = curationService.createCuration(
-			"before title",
-			"before content",
-			List.of("https://www.google.com", "https://www.naver.com"),
-			List.of("변경전 태그", "예시 태그")
-		);
+		Curation savedCuration = curationService.createCuration("before title", "before content",
+			List.of("https://www.google.com", "https://www.naver.com"), List.of("변경전 태그", "예시 태그"));
 
-		mockMvc.perform(put("/api/v1/curation/{id}", savedCuration.getId())
-				.contentType("application/json")
+		mockMvc.perform(put("/api/v1/curation/{id}", savedCuration.getId()).contentType("application/json")
 				.content(new ObjectMapper().writeValueAsString(curationReqDTO)))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("200-1"))
@@ -104,8 +103,7 @@ public class ApiV1CurationControllerTest {
 	// 글 삭제 테스트
 	@Test
 	void deleteCuration() throws Exception {
-		mockMvc.perform(delete("/api/v1/curation/{id}", 1L))
-			.andExpect(status().isNoContent());
+		mockMvc.perform(delete("/api/v1/curation/{id}", 1L)).andExpect(status().isNoContent());
 	}
 
 	// 글 조회 테스트
@@ -127,16 +125,14 @@ public class ApiV1CurationControllerTest {
 	@Test
 	void findAll() throws Exception {
 		for (int i = 0; i < 10; i++) {
-			curationService.createCuration(
-				curationReqDTO.getTitle(),
-				curationReqDTO.getContent(),
-				curationReqDTO.getLinkReqDtos().stream()
+			curationService.createCuration(curationReqDTO.getTitle(), curationReqDTO.getContent(),
+				curationReqDTO.getLinkReqDtos()
+					.stream()
 					.map(linkReqDto -> linkReqDto.getUrl())
-					.collect(Collectors.toUnmodifiableList()),
-				curationReqDTO.getTagReqDtos().stream()
+					.collect(Collectors.toUnmodifiableList()), curationReqDTO.getTagReqDtos()
+					.stream()
 					.map(tagReqDto -> tagReqDto.getName())
-					.collect(Collectors.toUnmodifiableList())
-			);
+					.collect(Collectors.toUnmodifiableList()));
 		}
 
 		mockMvc.perform(get("/api/v1/curation"))
@@ -153,8 +149,7 @@ public class ApiV1CurationControllerTest {
 		createCurationWithTags(List.of("ex2", "ex3", "ex4", "ex5"));
 		createCurationWithTags(List.of("ex2", "ex1", "ex3"));
 
-		mockMvc.perform(get("/api/v1/curation")
-				.param("tags", "ex1"))
+		mockMvc.perform(get("/api/v1/curation").param("tags", "ex1"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("200-1"))
 			.andExpect(jsonPath("$.msg").value("글이 검색되었습니다."))
@@ -162,14 +157,11 @@ public class ApiV1CurationControllerTest {
 	}
 
 	private Curation createCurationWithTags(List<String> tags) {
-		return curationService.createCuration(
-			curationReqDTO.getTitle(),
-			curationReqDTO.getContent(),
-			curationReqDTO.getLinkReqDtos().stream()
+		return curationService.createCuration(curationReqDTO.getTitle(), curationReqDTO.getContent(),
+			curationReqDTO.getLinkReqDtos()
+				.stream()
 				.map(linkReqDto -> linkReqDto.getUrl())
-				.collect(Collectors.toUnmodifiableList()),
-			tags
-		);
+				.collect(Collectors.toUnmodifiableList()), tags);
 	}
 
 	// 제목으로 글 검색
@@ -179,8 +171,7 @@ public class ApiV1CurationControllerTest {
 		createCurationWithTitle("test-ex");
 		createCurationWithTitle("test");
 
-		mockMvc.perform(get("/api/v1/curation")
-				.param("title", "ex"))
+		mockMvc.perform(get("/api/v1/curation").param("title", "ex"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("200-1"))
 			.andExpect(jsonPath("$.msg").value("글이 검색되었습니다."))
@@ -188,16 +179,13 @@ public class ApiV1CurationControllerTest {
 	}
 
 	private Curation createCurationWithTitle(String title) {
-		return curationService.createCuration(
-			title,
-			curationReqDTO.getContent(),
-			curationReqDTO.getLinkReqDtos().stream()
-				.map(linkReqDto -> linkReqDto.getUrl())
-				.collect(Collectors.toUnmodifiableList()),
-			curationReqDTO.getTagReqDtos().stream()
-				.map(tagReqDto -> tagReqDto.getName())
-				.collect(Collectors.toUnmodifiableList())
-		);
+		return curationService.createCuration(title, curationReqDTO.getContent(), curationReqDTO.getLinkReqDtos()
+			.stream()
+			.map(linkReqDto -> linkReqDto.getUrl())
+			.collect(Collectors.toUnmodifiableList()), curationReqDTO.getTagReqDtos()
+			.stream()
+			.map(tagReqDto -> tagReqDto.getName())
+			.collect(Collectors.toUnmodifiableList()));
 	}
 
 	// 내용으로 글 검색
@@ -207,8 +195,7 @@ public class ApiV1CurationControllerTest {
 		createCurationWithContent("test-example");
 		createCurationWithContent("test");
 
-		mockMvc.perform(get("/api/v1/curation")
-				.param("content", "example"))
+		mockMvc.perform(get("/api/v1/curation").param("content", "example"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("200-1"))
 			.andExpect(jsonPath("$.msg").value("글이 검색되었습니다."))
@@ -216,16 +203,13 @@ public class ApiV1CurationControllerTest {
 	}
 
 	private Curation createCurationWithContent(String content) {
-		return curationService.createCuration(
-			curationReqDTO.getTitle(),
-			content,
-			curationReqDTO.getLinkReqDtos().stream()
-				.map(linkReqDto -> linkReqDto.getUrl())
-				.collect(Collectors.toUnmodifiableList()),
-			curationReqDTO.getTagReqDtos().stream()
-				.map(tagReqDto -> tagReqDto.getName())
-				.collect(Collectors.toUnmodifiableList())
-		);
+		return curationService.createCuration(curationReqDTO.getTitle(), content, curationReqDTO.getLinkReqDtos()
+			.stream()
+			.map(linkReqDto -> linkReqDto.getUrl())
+			.collect(Collectors.toUnmodifiableList()), curationReqDTO.getTagReqDtos()
+			.stream()
+			.map(tagReqDto -> tagReqDto.getName())
+			.collect(Collectors.toUnmodifiableList()));
 	}
 
 	// 제목과 내용으로 글 검색
@@ -235,9 +219,7 @@ public class ApiV1CurationControllerTest {
 		createCurationWithTitleAndContent("sample", "test-famous");
 		createCurationWithTitleAndContent("test", "test");
 
-		mockMvc.perform(get("/api/v1/curation")
-				.param("title", "popular")
-				.param("content", "famous"))
+		mockMvc.perform(get("/api/v1/curation").param("title", "popular").param("content", "famous"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("200-1"))
 			.andExpect(jsonPath("$.msg").value("글이 검색되었습니다."))
@@ -245,16 +227,13 @@ public class ApiV1CurationControllerTest {
 	}
 
 	private Curation createCurationWithTitleAndContent(String title, String content) {
-		return curationService.createCuration(
-			title,
-			content,
-			curationReqDTO.getLinkReqDtos().stream()
-				.map(linkReqDto -> linkReqDto.getUrl())
-				.collect(Collectors.toUnmodifiableList()),
-			curationReqDTO.getTagReqDtos().stream()
-				.map(tagReqDto -> tagReqDto.getName())
-				.collect(Collectors.toUnmodifiableList())
-		);
+		return curationService.createCuration(title, content, curationReqDTO.getLinkReqDtos()
+			.stream()
+			.map(linkReqDto -> linkReqDto.getUrl())
+			.collect(Collectors.toUnmodifiableList()), curationReqDTO.getTagReqDtos()
+			.stream()
+			.map(tagReqDto -> tagReqDto.getName())
+			.collect(Collectors.toUnmodifiableList()));
 	}
 
 	// 최신순으로 글 조회
@@ -264,8 +243,7 @@ public class ApiV1CurationControllerTest {
 		createCurationWithTitleAndContent("title2", "content2");
 		createCurationWithTitleAndContent("title3", "content3");
 
-		mockMvc.perform(get("/api/v1/curation")
-				.param("order", "LATEST"))
+		mockMvc.perform(get("/api/v1/curation").param("order", "LATEST"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("200-1"))
 			.andExpect(jsonPath("$.msg").value("글이 검색되었습니다."))
@@ -281,8 +259,7 @@ public class ApiV1CurationControllerTest {
 		createCurationWithTitleAndContent("title2", "content2");
 		createCurationWithTitleAndContent("title3", "content3");
 
-		mockMvc.perform(get("/api/v1/curation")
-				.param("order", "OLDEST"))
+		mockMvc.perform(get("/api/v1/curation").param("order", "OLDEST"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("200-1"))
 			.andExpect(jsonPath("$.msg").value("글이 검색되었습니다."))
@@ -291,62 +268,91 @@ public class ApiV1CurationControllerTest {
 			.andExpect(jsonPath("$.data[3].content").value("content3"));
 	}
 
-    // 좋아요순으로 글 조회
-    @Test
-    void findCurationByLikeCount() throws Exception {
-        createCurationWithTitleAndContentAndLikeCount("title1", "content1", 4L);
-        createCurationWithTitleAndContentAndLikeCount("title2", "content2", 10L);
-        createCurationWithTitleAndContentAndLikeCount("title3", "content3", 2L);
+	// 좋아요순으로 글 조회
+	@Test
+	void findCurationByLikeCount() throws Exception {
+		createCurationWithTitleAndContentAndLikeCount("title1", "content1", 4L);
+		createCurationWithTitleAndContentAndLikeCount("title2", "content2", 10L);
+		createCurationWithTitleAndContentAndLikeCount("title3", "content3", 2L);
 
-        mockMvc.perform(get("/api/v1/curation")
-                        .param("order", "LIKECOUNT"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value("200-1"))
-                .andExpect(jsonPath("$.msg").value("글이 검색되었습니다."))
-                .andExpect(jsonPath("$.data[0].content").value("content2"))
-                .andExpect(jsonPath("$.data[1].content").value("content1"))
-                .andExpect(jsonPath("$.data[2].content").value("content3"));
-    }
+		mockMvc.perform(get("/api/v1/curation").param("order", "LIKECOUNT"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("200-1"))
+			.andExpect(jsonPath("$.msg").value("글이 검색되었습니다."))
+			.andExpect(jsonPath("$.data[0].content").value("content2"))
+			.andExpect(jsonPath("$.data[1].content").value("content1"))
+			.andExpect(jsonPath("$.data[2].content").value("content3"));
+	}
 
-    private Curation createCurationWithTitleAndContentAndLikeCount(String title, String content, Long likeCount) {
-        Curation curation = curationService.createCuration(
-                title,
-                content,
-                curationReqDTO.getLinkReqDtos().stream()
-                        .map(linkReqDto -> linkReqDto.getUrl())
-                        .collect(Collectors.toList()),
-                curationReqDTO.getTagReqDtos().stream()
-                        .map(tagReqDto -> tagReqDto.getName())
-                        .collect(Collectors.toList())
-        );
+	private Curation createCurationWithTitleAndContentAndLikeCount(String title, String content, Long likeCount) {
+		Curation curation = curationService.createCuration(title, content, curationReqDTO.getLinkReqDtos()
+				.stream()
+				.map(linkReqDto -> linkReqDto.getUrl())
+				.collect(Collectors.toList()),
+			curationReqDTO.getTagReqDtos().stream().map(tagReqDto -> tagReqDto.getName()).collect(Collectors.toList()));
 
 		curation.setLikeCount(likeCount);
 		curationRepository.save(curation);
-        return curation;
-    }
+		return curation;
+	}
 
-    // 좋아요 테스트
-    @Test
-    void likeCuration() throws Exception {
-        // 테스트용 데이터 저장
-        Curation savedCuration = curationService.createCuration(
-                "Test Title",
-                "Test Content",
-                curationReqDTO.getLinkReqDtos().stream()
-                        .map(linkReqDto -> linkReqDto.getUrl())
-                        .collect(Collectors.toUnmodifiableList()),
-                curationReqDTO.getTagReqDtos().stream()
-                        .map(tagReqDto -> tagReqDto.getName())
-                        .collect(Collectors.toUnmodifiableList())
-        );
+	// 좋아요 테스트
+	@Test
+	void likeCuration() throws Exception {
+		// 테스트용 데이터 저장
+		Curation savedCuration = curationService.createCuration("Test Title", "Test Content",
+			curationReqDTO.getLinkReqDtos()
+				.stream()
+				.map(linkReqDto -> linkReqDto.getUrl())
+				.collect(Collectors.toUnmodifiableList()), curationReqDTO.getTagReqDtos()
+				.stream()
+				.map(tagReqDto -> tagReqDto.getName())
+				.collect(Collectors.toUnmodifiableList()));
 
-        Long memberId = 1L; // 테스트용 회원 ID
+		Long memberId = 1L; // 테스트용 회원 ID
 
-        mockMvc.perform(post("/api/v1/curation/{id}", savedCuration.getId())
-                        .param("memberId", String.valueOf(memberId)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value("200-1"))
-                .andExpect(jsonPath("$.msg").value("글에 좋아요를 했습니다."))
-                .andExpect(jsonPath("$.data").doesNotExist()); // 응답 데이터가 없음을 확인
-    }
+		mockMvc.perform(
+				post("/api/v1/curation/{id}", savedCuration.getId()).param("memberId", String.valueOf(memberId)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("200-1"))
+			.andExpect(jsonPath("$.msg").value("글에 좋아요를 했습니다."))
+			.andExpect(jsonPath("$.data").doesNotExist()); // 응답 데이터가 없음을 확인
+	}
+
+	@Test
+	void findCurationByAuthor() throws Exception {
+		var author1 = createMember("author1");
+		var author2 = createMember("author2");
+
+		createCurationWithTitleAndMember("title1", author1);
+		createCurationWithTitleAndMember("title2", author2);
+		createCurationWithTitleAndMember("title3", author1);
+
+		mockMvc.perform(get("/api/v1/curation").param("author", "author1"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("200-1"))
+			.andExpect(jsonPath("$.msg").value("글이 검색되었습니다."))
+			.andExpect(jsonPath("$.data.length()").value(2));
+	}
+
+	private Member createMember(String author) {
+		Member member = Member.builder()
+			.email(author + "@gmail.com")
+			.role(RoleEnum.MEMBER)
+			.apiKey(author)
+			.memberId(author)
+			.username(author)
+			.password("password")
+			.profileImage("http://localhost:8080/images/team8-logo.png")
+			.build();
+
+		return memberRepository.save(member);
+	}
+
+	private void createCurationWithTitleAndMember(String title, Member author) {
+		Curation curation = curationService.createCuration(title, "example content", List.of("https://www.google.com/"),
+			List.of("tag1", "tag2"));
+		curation.setMember(author);
+		curationRepository.save(curation);
+	}
 }

--- a/backend/project2/src/test/java/com/team8/project2/domain/curation/service/CurationServiceTest.java
+++ b/backend/project2/src/test/java/com/team8/project2/domain/curation/service/CurationServiceTest.java
@@ -211,10 +211,10 @@ class CurationServiceTest {
 
 	@Test
 	void findAllCuration() {
-		when(curationRepository.searchByFilters(ArgumentMatchers.anyList(), anyInt(), anyString(), anyString(), any()))
+		when(curationRepository.searchByFilters(ArgumentMatchers.anyList(), anyInt(), anyString(), anyString(), any(), any()))
 			.thenReturn(List.of(curation));
 
-		List<Curation> foundCurations = curationService.searchCurations(List.of("tag"), "title", "content",
+		List<Curation> foundCurations = curationService.searchCurations(List.of("tag"), "title", "content", null,
 			SearchOrder.LATEST);
 
 		// Verify the result

--- a/backend/project2/src/test/java/com/team8/project2/domain/playlist/service/PlaylistServiceTest.java
+++ b/backend/project2/src/test/java/com/team8/project2/domain/playlist/service/PlaylistServiceTest.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Optional;
 import java.util.List;
 import java.util.Arrays;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -40,6 +41,7 @@ class PlaylistServiceTest {
         samplePlaylist = Playlist.builder()
                 .id(1L)
                 .title("테스트 플레이리스트")
+                .tags(Set.of())
                 .description("테스트 설명")
                 .build();
     }
@@ -56,6 +58,7 @@ class PlaylistServiceTest {
                 .id(2L)
                 .title(request.getTitle())
                 .description(request.getDescription())
+                .tags(Set.of())
                 .build();
 
         when(playlistRepository.save(any(Playlist.class))).thenReturn(newPlaylist);

--- a/frontend/project2/app/[username]/page.tsx
+++ b/frontend/project2/app/[username]/page.tsx
@@ -1,0 +1,330 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import Image from "next/image";
+import {
+  Heart,
+  MessageSquare,
+  Bookmark,
+  Share2,
+  ArrowLeft,
+} from "lucide-react";
+import { ClipLoader } from "react-spinners";
+
+// Curation 데이터 인터페이스 정의
+interface Curation {
+  id: number;
+  title: string;
+  content: string;
+  createdBy?: string;
+  createdAt: string;
+  modifiedAt: string;
+  likeCount: number;
+  urls: { url: string }[];
+  tags: { name: string }[];
+}
+
+// Link 메타 데이터 인터페이스 정의
+interface LinkMetaData {
+  url: string;
+  title: string;
+  description: string;
+  image: string;
+}
+
+export default function CuratorProfile({
+  params,
+}: {
+  params: { username: string };
+}) {
+  const [curations, setCurations] = useState<Curation[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const [linkMetaDataList, setLinkMetaDataList] = useState<{
+    [key: number]: LinkMetaData[];
+  }>({});
+  const [curatorStats, setCuratorStats] = useState({
+    totalCurations: 0,
+    totalLikes: 0,
+  });
+
+  // API 요청 함수
+  const fetchCuratorCurations = async (username: string) => {
+    setLoading(true);
+    try {
+      const response = await fetch(
+        `http://localhost:8080/api/v1/curation?author=${username}`
+      );
+
+      if (!response.ok) {
+        throw new Error("큐레이터 데이터를 불러오는 데 실패했습니다.");
+      }
+
+      const data = await response.json();
+
+      if (data && data.data) {
+        setCurations(data.data);
+
+        // 큐레이터 통계 계산
+        const totalCurations = data.data.length;
+        const totalLikes = data.data.reduce(
+          (sum: number, curation: Curation) => sum + curation.likeCount,
+          0
+        );
+
+        setCuratorStats({
+          totalCurations,
+          totalLikes,
+        });
+      } else {
+        console.error("No data found in the response");
+        setCurations([]);
+      }
+    } catch (error) {
+      console.error("Error fetching curator curations:", error);
+      setError((error as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // 메타 데이터 추출 함수
+  const fetchLinkMetaData = async (url: string, curationId: number) => {
+    try {
+      const response = await fetch(
+        `http://localhost:8080/api/v1/link/preview`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ url: url }),
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error("Failed to fetch link metadata");
+      }
+
+      const data = await response.json();
+      setLinkMetaDataList((prev) => {
+        const existingMetaData = prev[curationId] || [];
+        const newMetaData = existingMetaData.filter(
+          (meta) => meta.url !== data.data.url
+        );
+        return {
+          ...prev,
+          [curationId]: [...newMetaData, data.data],
+        };
+      });
+    } catch (error) {
+      console.error("Error fetching link metadata:", error);
+    }
+  };
+
+  // 큐레이션마다 메타 데이터 추출
+  useEffect(() => {
+    curations.forEach((curation) => {
+      if (curation.urls && curation.urls.length > 0) {
+        curation.urls.forEach((urlObj) => {
+          if (
+            !linkMetaDataList[curation.id]?.some(
+              (meta) => meta.url === urlObj.url
+            )
+          ) {
+            fetchLinkMetaData(urlObj.url, curation.id);
+          }
+        });
+      }
+    });
+  }, [curations, linkMetaDataList]);
+
+  // 날짜 형식화 함수
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    const hours = String(date.getHours()).padStart(2, "0");
+    const minutes = String(date.getMinutes()).padStart(2, "0");
+    return `${year}년 ${month}월 ${day}일 ${hours}:${minutes}`;
+  };
+
+  // 컴포넌트 마운트 시 API 호출
+  useEffect(() => {
+    fetchCuratorCurations(params.username);
+  }, [params.username]);
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      {/* 뒤로 가기 버튼 */}
+      <div className="mb-6">
+        <Link
+          href="/"
+          className="inline-flex items-center text-sm text-gray-500 hover:text-black"
+        >
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          홈으로 돌아가기
+        </Link>
+      </div>
+
+      {/* 큐레이터 프로필 */}
+      <div className="mb-8 p-6 bg-white rounded-lg border shadow-sm">
+        <div className="flex flex-col md:flex-row items-center md:items-start gap-6">
+          <div className="w-24 h-24 rounded-full overflow-hidden bg-gray-100 flex-shrink-0">
+            <Image
+              src={`/placeholder.svg?height=96&width=96`}
+              alt={params.username}
+              width={96}
+              height={96}
+              className="object-cover"
+            />
+          </div>
+          <div className="flex-1 text-center md:text-left">
+            <h1 className="text-2xl font-bold mb-2">{params.username}</h1>
+            <p className="text-gray-600 mb-4">
+              큐레이터 {params.username}님의 큐레이션 모음입니다.
+            </p>
+            <div className="flex flex-wrap justify-center md:justify-start gap-4">
+              <div className="text-center">
+                <p className="text-2xl font-bold">
+                  {curatorStats.totalCurations}
+                </p>
+                <p className="text-sm text-gray-500">큐레이션</p>
+              </div>
+              <div className="text-center">
+                <p className="text-2xl font-bold">{curatorStats.totalLikes}</p>
+                <p className="text-sm text-gray-500">좋아요</p>
+              </div>
+            </div>
+          </div>
+          <div className="flex-shrink-0">
+            <button className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors">
+              팔로우
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* 큐레이션 목록 제목 */}
+      <h2 className="text-xl font-bold mb-6 border-b pb-2">
+        {params.username}님의 큐레이션 ({curatorStats.totalCurations})
+      </h2>
+
+      {/* 로딩 상태 표시 */}
+      {loading ? (
+        <div className="flex justify-center items-center py-10">
+          <ClipLoader size={50} color="#3498db" />
+        </div>
+      ) : error ? (
+        <div className="p-6 bg-red-50 text-red-600 rounded-lg border border-red-200">
+          <p className="font-medium">오류가 발생했습니다</p>
+          <p className="text-sm mt-1">{error}</p>
+        </div>
+      ) : curations.length === 0 ? (
+        <div className="p-10 bg-gray-50 rounded-lg border text-center">
+          <p className="text-gray-500">아직 작성한 큐레이션이 없습니다.</p>
+        </div>
+      ) : (
+        /* 큐레이션 목록 */
+        <div className="space-y-6">
+          {curations.map((curation) => (
+            <div key={curation.id} className="space-y-4 border-b pb-6">
+              <div className="flex items-center space-x-2">
+                <p className="text-xs text-gray-500">{`작성된 날짜 : ${formatDate(
+                  curation.createdAt
+                )}`}</p>
+              </div>
+
+              <div>
+                <Link href={`/post/${curation.id}`} className="group">
+                  <h2 className="text-xl font-bold group-hover:text-blue-600">
+                    {curation.title}
+                  </h2>
+                </Link>
+                <p className="mt-2 text-gray-600">
+                  {curation.content.length > 100
+                    ? `${curation.content.substring(0, 100)}...`
+                    : curation.content}
+                </p>
+                <Link
+                  href={`/post/${curation.id}`}
+                  className="mt-2 inline-block text-sm font-medium text-blue-600"
+                >
+                  더보기
+                </Link>
+              </div>
+
+              {/* 태그 표시 */}
+              <div className="flex flex-wrap gap-2 mt-2">
+                {curation.tags.map((tag) => (
+                  <span
+                    key={tag.name}
+                    className={`px-3 py-1 text-sm font-medium rounded-full cursor-pointer ${
+                      tag.name === "포털"
+                        ? "bg-blue-100 text-blue-800"
+                        : tag.name === "개발"
+                        ? "bg-green-100 text-green-800"
+                        : tag.name === "디자인"
+                        ? "bg-purple-100 text-purple-800"
+                        : tag.name === "AI"
+                        ? "bg-red-100 text-red-800"
+                        : tag.name === "생산성"
+                        ? "bg-yellow-100 text-yellow-800"
+                        : "bg-gray-100 text-gray-800"
+                    }`}
+                  >
+                    #{tag.name}
+                  </span>
+                ))}
+              </div>
+
+              {/* 메타 데이터 카드 */}
+              {linkMetaDataList[curation.id]?.map((metaData, index) => (
+                <Link key={index} href={metaData.url} passHref>
+                  <div className="mt-4 rounded-lg border p-4 cursor-pointer hover:bg-gray-50 transition-colors">
+                    <div className="flex items-center space-x-3">
+                      <img
+                        src={metaData.image || "/placeholder.svg"}
+                        alt="Preview"
+                        className="h-12 w-12 rounded-lg object-cover"
+                      />
+                      <div>
+                        <h3 className="font-medium">{metaData.title}</h3>
+                        <p className="text-sm text-gray-600 line-clamp-1">
+                          {metaData.description}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </Link>
+              ))}
+
+              <div className="flex items-center justify-between">
+                <div className="flex items-center space-x-4">
+                  <div className="flex items-center space-x-1 text-sm text-gray-500">
+                    <Heart className="h-4 w-4" />
+                    <span>{curation.likeCount}</span>
+                  </div>
+                  <div className="flex items-center space-x-1 text-sm text-gray-500">
+                    <MessageSquare className="h-4 w-4" />
+                    <span>0</span>
+                  </div>
+                </div>
+                <div className="flex space-x-2">
+                  <button>
+                    <Bookmark className="h-4 w-4 text-gray-500" />
+                  </button>
+                  <button>
+                    <Share2 className="h-4 w-4 text-gray-500" />
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/project2/app/[username]/page.tsx
+++ b/frontend/project2/app/[username]/page.tsx
@@ -238,7 +238,7 @@ export default function CuratorProfile({
               </div>
 
               <div>
-                <Link href={`/post/${curation.id}`} className="group">
+                <Link href={`/curation/${curation.id}`} className="group">
                   <h2 className="text-xl font-bold group-hover:text-blue-600">
                     {curation.title}
                   </h2>
@@ -249,7 +249,7 @@ export default function CuratorProfile({
                     : curation.content}
                 </p>
                 <Link
-                  href={`/post/${curation.id}`}
+                  href={`/curation/${curation.id}`}
                   className="mt-2 inline-block text-sm font-medium text-blue-600"
                 >
                   더보기

--- a/frontend/project2/app/components/post-list.tsx
+++ b/frontend/project2/app/components/post-list.tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 import { Heart, MessageSquare, Bookmark, Share2 } from "lucide-react";
 import { ClipLoader } from "react-spinners"; // 로딩 애니메이션
 
-
 // Curation 데이터 인터페이스 정의
 interface Curation {
   id: number;
@@ -39,7 +38,9 @@ export default function PostList() {
   const [curations, setCurations] = useState<Curation[]>([]);
   const [sortOrder, setSortOrder] = useState<SortOrder>("LATEST"); // 기본값: 최신순
   const [loading, setLoading] = useState<boolean>(false);
-  const [linkMetaDataList, setLinkMetaDataList] = useState<{ [key: number]: LinkMetaData[] }>({}); // 각 큐레이션에 대한 메타 데이터 상태 (배열로 수정)
+  const [linkMetaDataList, setLinkMetaDataList] = useState<{
+    [key: number]: LinkMetaData[];
+  }>({}); // 각 큐레이션에 대한 메타 데이터 상태 (배열로 수정)
   const [filterModalOpen, setFilterModalOpen] = useState(false); // 필터 모달 상태
   const [tags, setTags] = useState<string[]>([]); // 선택된 태그 상태
   const [selectedTags, setSelectedTags] = useState<string[]>([]); // 필터링된 태그 상태
@@ -52,12 +53,16 @@ export default function PostList() {
     try {
       const queryParams = new URLSearchParams({
         order: sortOrder, // 기존의 sortOrder 상태를 직접 전달
-        ...(params.tags && params.tags.length > 0 ? { tags: params.tags.join(",") } : {}),
+        ...(params.tags && params.tags.length > 0
+          ? { tags: params.tags.join(",") }
+          : {}),
         ...(params.title ? { title: params.title } : {}),
         ...(params.content ? { content: params.content } : {}),
       }).toString();
 
-      const response = await fetch(`http://localhost:8080/api/v1/curation?${queryParams}`);
+      const response = await fetch(
+        `http://localhost:8080/api/v1/curation?${queryParams}`
+      );
       if (!response.ok) {
         throw new Error("Network response was not ok");
       }
@@ -74,7 +79,6 @@ export default function PostList() {
     }
   };
 
-
   // 필터 버튼 클릭 시
   const openFilterModal = () => {
     setFilterModalOpen(true);
@@ -86,35 +90,36 @@ export default function PostList() {
 
   // 필터링 조건을 기반으로 API 호출
   const applyFilter = () => {
-
     setSelectedTags(tags); // 입력한 tags를 selectedTags에 동기화
 
     const params: CurationRequestParams = {
       tags: selectedTags,
       title,
       content,
-      order: sortOrder,  // 정렬 기준도 함께 보내기
+      order: sortOrder, // 정렬 기준도 함께 보내기
     };
     fetchCurations(params);
     closeFilterModal();
   };
-  
 
   // 메타 데이터 추출 함수
   const fetchLinkMetaData = async (url: string, curationId: number) => {
     try {
-      const response = await fetch(`http://localhost:8080/api/v1/link/preview`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ "url": url }), // body에 JSON 형태로 URL을 전달
-      });
-  
+      const response = await fetch(
+        `http://localhost:8080/api/v1/link/preview`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ url: url }), // body에 JSON 형태로 URL을 전달
+        }
+      );
+
       if (!response.ok) {
         throw new Error("Failed to fetch link metadata");
       }
-  
+
       const data = await response.json();
       setLinkMetaDataList((prev) => {
         const existingMetaData = prev[curationId] || [];
@@ -131,14 +136,16 @@ export default function PostList() {
       console.error("Error fetching link metadata:", error);
     }
   };
-  
 
   // 좋아요 추가 API 호출 함수
   const likeCuration = async (id: number) => {
     try {
-      const response = await fetch(`http://localhost:8080/api/v1/curation/${id}`, {
-        method: 'POST', // POST 요청으로 좋아요 추가
-      });
+      const response = await fetch(
+        `http://localhost:8080/api/v1/curation/${id}`,
+        {
+          method: "POST", // POST 요청으로 좋아요 추가
+        }
+      );
       if (!response.ok) {
         throw new Error("Failed to like the post");
       }
@@ -148,7 +155,7 @@ export default function PostList() {
         tags: selectedTags,
         title,
         content,
-        order: sortOrder,  // 정렬 기준도 함께 보내기
+        order: sortOrder, // 정렬 기준도 함께 보내기
       };
       fetchCurations(params);
     } catch (error) {
@@ -160,18 +167,19 @@ export default function PostList() {
   useEffect(() => {
     curations.forEach((curation) => {
       if (curation.urls.length > 0) {
-        curation.urls.forEach(urlObj => {
+        curation.urls.forEach((urlObj) => {
           // URL이 이미 메타 데이터에 포함되지 않았다면 메타 데이터를 가져옴
-          if (!linkMetaDataList[curation.id]?.some(meta => meta.url === urlObj.url)) {
+          if (
+            !linkMetaDataList[curation.id]?.some(
+              (meta) => meta.url === urlObj.url
+            )
+          ) {
             fetchLinkMetaData(urlObj.url, curation.id); // 메타 데이터 가져오기
           }
         });
       }
     });
   }, [curations, linkMetaDataList]); // linkMetaDataList도 의존성에 추가
-
-
-  
 
   // 날짜 형식화 함수
   const formatDate = (dateString: string) => {
@@ -189,19 +197,19 @@ export default function PostList() {
       tags: selectedTags,
       title,
       content,
-      order: sortOrder,  // 정렬 기준도 함께 보내기
+      order: sortOrder, // 정렬 기준도 함께 보내기
     };
     fetchCurations(params);
   }, [selectedTags]);
 
   const toggleTagFilter = (tag: string) => {
-  setSelectedTags((prev) => {
-    if (prev.includes(tag)) {
-      return prev.filter((t) => t !== tag); // 이미 선택된 태그가 있으면 제거
-    }
-    return [...prev, tag]; // 선택되지 않은 태그가 있으면 추가
-  });
-};
+    setSelectedTags((prev) => {
+      if (prev.includes(tag)) {
+        return prev.filter((t) => t !== tag); // 이미 선택된 태그가 있으면 제거
+      }
+      return [...prev, tag]; // 선택되지 않은 태그가 있으면 추가
+    });
+  };
 
   useEffect(() => {
     fetchCurations({}); // 페이지 로딩 시 한번 API 호출
@@ -225,7 +233,9 @@ export default function PostList() {
           <div className="bg-white p-6 rounded-lg w-96">
             <h3 className="text-xl font-semibold mb-4">필터링 조건</h3>
             <div className="mb-4">
-              <label className="block text-sm font-medium text-gray-700">태그</label>
+              <label className="block text-sm font-medium text-gray-700">
+                태그
+              </label>
               <input
                 type="text"
                 defaultValue={selectedTags.join(", ")}
@@ -242,7 +252,9 @@ export default function PostList() {
               />
             </div>
             <div className="mb-4">
-              <label className="block text-sm font-medium text-gray-700">제목</label>
+              <label className="block text-sm font-medium text-gray-700">
+                제목
+              </label>
               <input
                 type="text"
                 value={title}
@@ -252,7 +264,9 @@ export default function PostList() {
               />
             </div>
             <div className="mb-4">
-              <label className="block text-sm font-medium text-gray-700">내용</label>
+              <label className="block text-sm font-medium text-gray-700">
+                내용
+              </label>
               <input
                 type="text"
                 value={content}
@@ -263,7 +277,9 @@ export default function PostList() {
             </div>
             {/* 정렬 기준 드롭다운 추가 */}
             <div className="mb-4">
-              <label className="block text-sm font-medium text-gray-700">정렬 기준</label>
+              <label className="block text-sm font-medium text-gray-700">
+                정렬 기준
+              </label>
               <select
                 value={sortOrder}
                 onChange={(e) => setSortOrder(e.target.value as SortOrder)} // value 변경 시 sortOrder 업데이트
@@ -296,103 +312,107 @@ export default function PostList() {
         <div className="flex justify-center items-center py-10">
           <ClipLoader size={50} color="#3498db" />
         </div>
-      ) : /* 게시글 목록 */
-      <div className="space-y-6 pt-4">
-        {curations.length === 0 ? (
-          <p>글이 없습니다.</p>
-        ) : (
-          curations.map((curation) => (
-            <div key={curation.id} className="space-y-4 border-b pb-6">
-              <div className="flex items-center space-x-2">
-              <p className="text-xs text-gray-500">
-                {
-                  `작성된 날짜 : ${formatDate(curation.createdAt)}`
-                /* {Math.floor(new Date(curation.modifiedAt).getTime() / 1000) !== Math.floor(new Date(curation.createdAt).getTime() / 1000)
+      ) : (
+        /* 게시글 목록 */
+        <div className="space-y-6 pt-4">
+          {curations.length === 0 ? (
+            <p>글이 없습니다.</p>
+          ) : (
+            curations.map((curation) => (
+              <div key={curation.id} className="space-y-4 border-b pb-6">
+                <div className="flex items-center space-x-2">
+                  <p className="text-xs text-gray-500">
+                    {
+                      `작성된 날짜 : ${formatDate(curation.createdAt)}`
+                      /* {Math.floor(new Date(curation.modifiedAt).getTime() / 1000) !== Math.floor(new Date(curation.createdAt).getTime() / 1000)
                   ? `수정된 날짜 : ${formatDate(curation.modifiedAt)}`
                   : `작성된 날짜 : ${formatDate(curation.createdAt)}`} */
-                  }
-              </p>
-              </div>
+                    }
+                  </p>
+                </div>
 
-              <div>
-                <Link href={`/post/${curation.id}`} className="group">
-                  <h2 className="text-xl font-bold group-hover:text-blue-600">
-                    {curation.title}
-                  </h2>
-                </Link>
-                <p className="mt-2 text-gray-600">
-                  {curation.content.length > 100
-                    ? `${curation.content.substring(0, 100)}...`
-                    : curation.content}
-                </p>
-                <button className="mt-2 text-sm font-medium text-blue-600">더보기</button>
-              </div>
+                <div>
+                  <Link href={`/curation/${curation.id}`} className="group">
+                    <h2 className="text-xl font-bold group-hover:text-blue-600">
+                      {curation.title}
+                    </h2>
+                  </Link>
+                  <p className="mt-2 text-gray-600">
+                    {curation.content.length > 100
+                      ? `${curation.content.substring(0, 100)}...`
+                      : curation.content}
+                  </p>
+                  <button className="mt-2 text-sm font-medium text-blue-600">
+                    더보기
+                  </button>
+                </div>
 
-              {/* 태그 표시 */}
-              <div className="flex space-x-2 mt-2">
-                {curation.tags.map((tag) => (
-                  <span
-                    key={tag.name}
-                    className={`px-3 py-1 text-sm font-medium rounded-full cursor-pointer ${
-                      selectedTags.includes(tag.name) ? "bg-blue-600 text-white" : "bg-gray-200 text-gray-600"
-                    }`}
-                    onClick={() => toggleTagFilter(tag.name)}
-                  >
-                    {tag.name}
-                  </span>
-                ))}
-              </div>
+                {/* 태그 표시 */}
+                <div className="flex space-x-2 mt-2">
+                  {curation.tags.map((tag) => (
+                    <span
+                      key={tag.name}
+                      className={`px-3 py-1 text-sm font-medium rounded-full cursor-pointer ${
+                        selectedTags.includes(tag.name)
+                          ? "bg-blue-600 text-white"
+                          : "bg-gray-200 text-gray-600"
+                      }`}
+                      onClick={() => toggleTagFilter(tag.name)}
+                    >
+                      {tag.name}
+                    </span>
+                  ))}
+                </div>
 
-              {/* 메타 데이터 카드 */}
-              {linkMetaDataList[curation.id]?.map((metaData, index) => (
-                <Link key={index} href={metaData.url} passHref>
-                  <div className="mt-4 rounded-lg border p-4 cursor-pointer">
-                    <div className="flex items-center space-x-3">
-                      <img
-                        src={metaData.image}
-                        alt="Preview"
-                        className="h-12 w-12 rounded-lg"
-                      />
-                      <div>
-                        <h3 className="font-medium">{metaData.title}</h3>
-                        <p className="text-sm text-gray-600">
-                          {metaData.description}
-                        </p>
+                {/* 메타 데이터 카드 */}
+                {linkMetaDataList[curation.id]?.map((metaData, index) => (
+                  <Link key={index} href={metaData.url} passHref>
+                    <div className="mt-4 rounded-lg border p-4 cursor-pointer">
+                      <div className="flex items-center space-x-3">
+                        <img
+                          src={metaData.image}
+                          alt="Preview"
+                          className="h-12 w-12 rounded-lg"
+                        />
+                        <div>
+                          <h3 className="font-medium">{metaData.title}</h3>
+                          <p className="text-sm text-gray-600">
+                            {metaData.description}
+                          </p>
+                        </div>
                       </div>
                     </div>
-                  </div>
-                </Link>
-              ))}
+                  </Link>
+                ))}
 
-              <div className="flex items-center justify-between">
-                <div className="flex items-center space-x-4">
-                  <button
-                    className="flex items-center space-x-1 text-sm text-gray-500"
-                    onClick={() => likeCuration(curation.id)} // 좋아요 버튼 클릭 시 likeCuration 호출
-                  >
-                    <Heart className="h-4 w-4" />
-                    <span>{curation.likeCount}</span>
-                  </button>
-                  <button className="flex items-center space-x-1 text-sm text-gray-500">
-                    <MessageSquare className="h-4 w-4" />
-                    <span>12</span>
-                  </button>
-                </div>
-                <div className="flex space-x-2">
-                  <button>
-                    <Bookmark className="h-4 w-4 text-gray-500" />
-                  </button>
-                  <button>
-                    <Share2 className="h-4 w-4 text-gray-500" />
-                  </button>
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center space-x-4">
+                    <button
+                      className="flex items-center space-x-1 text-sm text-gray-500"
+                      onClick={() => likeCuration(curation.id)} // 좋아요 버튼 클릭 시 likeCuration 호출
+                    >
+                      <Heart className="h-4 w-4" />
+                      <span>{curation.likeCount}</span>
+                    </button>
+                    <button className="flex items-center space-x-1 text-sm text-gray-500">
+                      <MessageSquare className="h-4 w-4" />
+                      <span>12</span>
+                    </button>
+                  </div>
+                  <div className="flex space-x-2">
+                    <button>
+                      <Bookmark className="h-4 w-4 text-gray-500" />
+                    </button>
+                    <button>
+                      <Share2 className="h-4 w-4 text-gray-500" />
+                    </button>
+                  </div>
                 </div>
               </div>
-            </div>
-          ))
-        )}
-      </div>}
-
-      
+            ))
+          )}
+        </div>
+      )}
     </>
   );
 }

--- a/frontend/project2/app/curation/[id]/page.tsx
+++ b/frontend/project2/app/curation/[id]/page.tsx
@@ -259,15 +259,21 @@ export default function PostDetail({ params }: { params: { id: string } }) {
         <article className="space-y-6">
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-2">
-              <Image
-                src={post.authorImage || "/placeholder.svg?height=40&width=40"}
-                alt={post.authorName}
-                width={40}
-                height={40}
-                className="rounded-full"
-              />
+              <Link href={`/${post.authorName}`} className="group">
+                <Image
+                  src={
+                    post.authorImage || "/placeholder.svg?height=40&width=40"
+                  }
+                  alt={post.authorName}
+                  width={40}
+                  height={40}
+                  className="rounded-full"
+                />
+              </Link>
               <div>
-                <p className="font-medium">{post.authorName}</p>
+                <Link href={`/${post.authorName}`} className="group">
+                  <p className="font-medium">{post.authorName}</p>
+                </Link>
                 <p className="text-xs text-gray-500">
                   {isModified
                     ? `수정된 날짜: ${formatDate(post.modifiedAt)}`
@@ -409,15 +415,21 @@ export default function PostDetail({ params }: { params: { id: string } }) {
           <div className="rounded-lg border p-4">
             <h3 className="mb-3 font-semibold">이 글의 작성자</h3>
             <div className="flex items-center space-x-3">
-              <Image
-                src={post.authorImage || "/placeholder.svg?height=48&width=48"}
-                alt={post.authorName}
-                width={48}
-                height={48}
-                className="rounded-full"
-              />
+              <Link href={`/${post.authorName}`} className="group">
+                <Image
+                  src={
+                    post.authorImage || "/placeholder.svg?height=48&width=48"
+                  }
+                  alt={post.authorName}
+                  width={48}
+                  height={48}
+                  className="rounded-full"
+                />
+              </Link>
               <div>
-                <p className="font-medium">{post.authorName}</p>
+                <Link href={`/${post.authorName}`} className="group">
+                  <p className="font-medium">{post.authorName}</p>
+                </Link>
                 <p className="text-xs text-gray-500">15개의 글 작성</p>
               </div>
             </div>

--- a/frontend/project2/app/curation/[id]/page.tsx
+++ b/frontend/project2/app/curation/[id]/page.tsx
@@ -237,7 +237,7 @@ export default function PostDetail({ params }: { params: { id: string } }) {
               <div className="absolute right-0 mt-2 w-48 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-10">
                 <div className="py-1" role="menu" aria-orientation="vertical">
                   <Link
-                    href={`/post/${params.id}/edit`}
+                    href={`/curation/${params.id}/edit`}
                     className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
                   >
                     <Edit className="mr-2 h-4 w-4" />


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 특정 사용자(큐레이터)가 작성한 큐레이션을 조회 기능 추가
- 큐레이터의 큐레이션 페이지 작성
- 큐레이션 목록 - 큐레이션 상세 페이지 연결
- 큐레이션 상세 페이지 - 큐레이터 페이지 연결

**큐레이터 페이지**
<img width="1071" alt="스크린샷 2025-03-10 오전 9 31 52" src="https://github.com/user-attachments/assets/0a283ad8-28da-49bc-8521-75603bfe59ef" />

## 고려사항
- 큐레이터의 정보를 불러오는 부분은 Member 작업 필요
- 큐레이터가 작성한 글 수 Member API에 추가 필요

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

Closes #74 
