### PR TITLE
Feat/#92 팔로우중인 큐레이터의 큐레이션 조회

### DIFF
--- a/backend/project2/src/main/java/com/team8/project2/domain/curation/curation/controller/ApiV1CurationController.java
+++ b/backend/project2/src/main/java/com/team8/project2/domain/curation/curation/controller/ApiV1CurationController.java
@@ -10,6 +10,8 @@ import com.team8.project2.domain.member.entity.Member;
 import com.team8.project2.global.Rq;
 import com.team8.project2.global.dto.RsData;
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
@@ -142,5 +144,13 @@ public class ApiV1CurationController {
         Long memberId = rq.getActor().getId();
         curationService.likeCuration(id, memberId);
         return new RsData<>("200-1", "글에 좋아요를 했습니다.", null);
+    }
+
+    @GetMapping("/following")
+    @PreAuthorize("isAuthenticated()")
+    public RsData<List<CurationResDto>> followingCuration() {
+        Member actor = rq.getActor();
+        List<CurationResDto> curations = curationService.getFollowingCurations(actor);
+        return new RsData<>("200-1", "팔로우중인 큐레이터의 큐레이션이 조회되었습니다.", curations);
     }
 }

--- a/backend/project2/src/main/java/com/team8/project2/domain/curation/curation/repository/CurationRepository.java
+++ b/backend/project2/src/main/java/com/team8/project2/domain/curation/curation/repository/CurationRepository.java
@@ -76,4 +76,6 @@ public interface CurationRepository extends JpaRepository<Curation, Long> {
 		@Param("author") String author,
 		@Param("searchOrder") String searchOrder);
 
+	@Query("SELECT c FROM Curation c WHERE c.member IN (SELECT f.followee FROM Follow f WHERE f.follower.id = :userId) ORDER BY c.createdAt DESC")
+	List<Curation> findFollowingCurations(@Param("userId") Long userId);
 }

--- a/backend/project2/src/main/java/com/team8/project2/domain/curation/curation/service/CurationService.java
+++ b/backend/project2/src/main/java/com/team8/project2/domain/curation/curation/service/CurationService.java
@@ -1,5 +1,6 @@
 package com.team8.project2.domain.curation.curation.service;
 
+import com.team8.project2.domain.curation.curation.dto.CurationResDto;
 import com.team8.project2.domain.curation.curation.entity.Curation;
 import com.team8.project2.domain.curation.curation.entity.CurationLink;
 import com.team8.project2.domain.curation.curation.entity.CurationTag;
@@ -11,7 +12,9 @@ import com.team8.project2.domain.curation.like.entity.Like;
 import com.team8.project2.domain.curation.like.repository.LikeRepository;
 import com.team8.project2.domain.curation.tag.service.TagService;
 import com.team8.project2.domain.link.service.LinkService;
+import com.team8.project2.domain.member.entity.Follow;
 import com.team8.project2.domain.member.entity.Member;
+import com.team8.project2.domain.member.repository.FollowRepository;
 import com.team8.project2.domain.member.repository.MemberRepository;
 import com.team8.project2.global.exception.ServiceException;
 
@@ -21,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -39,6 +43,7 @@ public class CurationService {
 	private final TagService tagService;
 	private final MemberRepository memberRepository;
     private final LikeRepository likeRepository;
+	private final FollowRepository followRepository;
 
 	/**
 	 * ✅ 특정 큐레이터의 큐레이션 개수를 반환하는 메서드 추가
@@ -202,4 +207,11 @@ public class CurationService {
                 }
         );
     }
+
+	public List<CurationResDto> getFollowingCurations(Member member) {
+		List<Curation> followingCurations = curationRepository.findFollowingCurations(member.getId());
+		return followingCurations.stream()
+			.map(CurationResDto::new)
+			.collect(Collectors.toList());
+	}
 }

--- a/backend/project2/src/main/java/com/team8/project2/global/exception/GlobalExceptionHandler.java
+++ b/backend/project2/src/main/java/com/team8/project2/global/exception/GlobalExceptionHandler.java
@@ -74,9 +74,11 @@ public class GlobalExceptionHandler {
 
 	/** 401 - Unauthorized */
 	@ExceptionHandler(AccessDeniedException.class)
-	public RsData<Void> handleAccessDeniedException(AccessDeniedException ex) {
+	public ResponseEntity<RsData<Void>> handleAccessDeniedException(AccessDeniedException ex) {
 		// 예외 발생 시 반환할 메시지와 상태 코드 정의
-		return new RsData<>("401-1","접근이 거부되었습니다. 로그인 상태를 확인해 주세요.");
+		return ResponseEntity
+			.status(HttpStatus.UNAUTHORIZED)
+			.body(new RsData<>("401-1","접근이 거부되었습니다. 로그인 상태를 확인해 주세요."));
 	}
 
 	/** 500 - Internal Server Error */

--- a/backend/project2/src/test/java/com/team8/project2/domain/curation/controller/ApiV1CurationControllerTest.java
+++ b/backend/project2/src/test/java/com/team8/project2/domain/curation/controller/ApiV1CurationControllerTest.java
@@ -12,6 +12,7 @@ import com.team8.project2.domain.member.entity.RoleEnum;
 import com.team8.project2.domain.member.repository.MemberRepository;
 import com.team8.project2.domain.member.service.AuthTokenService;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -40,20 +41,24 @@ public class ApiV1CurationControllerTest {
 	@Autowired
 	private CurationService curationService; // 실제 서비스 사용
 
-	private CurationReqDTO curationReqDTO;
+	@Autowired
+	private AuthTokenService authTokenService;
+
 	@Autowired
 	private CurationRepository curationRepository;
 	@Autowired
 	private MemberRepository memberRepository;
 
+	private CurationReqDTO curationReqDTO;
+
 	String memberAccessKey;
 	Member member;
+
 
 	@BeforeEach
 	void setUp() {
 		member = memberRepository.findById(1L).get();
 		memberAccessKey = authTokenService.genAccessToken(member);
-
 
 		// CurationReqDTO 설정 (링크 포함)
 		curationReqDTO = new CurationReqDTO();
@@ -74,8 +79,8 @@ public class ApiV1CurationControllerTest {
 		curationReqDTO.setTagReqDtos(Collections.singletonList(tagReqDto));
 	}
 
-	// 글 생성 테스트
 	@Test
+	@DisplayName("큐레이션을 생성할 수 있다")
 	void createCuration() throws Exception {
 		mockMvc.perform(post("/api/v1/curation")
 				.header("Authorization", "Bearer " + memberAccessKey)
@@ -90,8 +95,8 @@ public class ApiV1CurationControllerTest {
 			.andExpect(jsonPath("$.data.tags[0].name").value("test"));
 	}
 
-	// 글 수정 테스트
 	@Test
+	@DisplayName("큐레이션을 수정할 수 있다")
 	void updateCuration() throws Exception {
 		Curation savedCuration = curationRepository.findById(1L).orElseThrow();
 
@@ -111,6 +116,7 @@ public class ApiV1CurationControllerTest {
 	}
 
 	@Test
+	@DisplayName("실패 - 작성자가 아니면 큐레이션 수정에 실패한다")
 	void updateCurationByOtherUser_ShouldFail() throws Exception {
 		// 다른 사용자 생성
 		Member anotherMember = Member.builder()
@@ -135,9 +141,8 @@ public class ApiV1CurationControllerTest {
 				.andExpect(status().isForbidden());
 	}
 
-
-	// 글 삭제 테스트
 	@Test
+	@DisplayName("큐레이션 작성자는 큐레이션을 삭제할 수 있다")
 	void deleteCuration() throws Exception {
 		Curation savedCuration = curationRepository.findById(1L).orElseThrow();
 
@@ -147,9 +152,8 @@ public class ApiV1CurationControllerTest {
 				.andExpect(status().isNoContent());
 	}
 
-
-	// 글 조회 테스트
 	@Test
+	@DisplayName("큐레이션을 조회할 수 있다")
 	void getCuration() throws Exception {
 		mockMvc.perform(get("/api/v1/curation/{id}", 1L))
 				.andExpect(status().isOk())
@@ -163,8 +167,8 @@ public class ApiV1CurationControllerTest {
 				.andExpect(jsonPath("$.data.comments[0].content").value("comment test content"));
 	}
 
-	// 글 전체 조회
 	@Test
+	@DisplayName("큐레이션을 전체 조회할 수 있다")
 	void findAll() throws Exception {
 		for (int i = 0; i < 10; i++) {
 			curationService.createCuration(curationReqDTO.getTitle(), curationReqDTO.getContent(),
@@ -184,8 +188,8 @@ public class ApiV1CurationControllerTest {
 				.andExpect(jsonPath("$.data.length()").value(11));
 	}
 
-	// 태그로 글 검색
 	@Test
+	@DisplayName("큐레이션을 태그로 검색할 수 있다")
 	void findCurationByTags() throws Exception {
 		createCurationWithTags(List.of("ex1", "ex2", "ex3"));
 		createCurationWithTags(List.of("ex2", "ex3", "ex4", "ex5"));
@@ -205,8 +209,8 @@ public class ApiV1CurationControllerTest {
 				.collect(Collectors.toUnmodifiableList()), tags, member);
 	}
 
-	// 제목으로 글 검색
 	@Test
+	@DisplayName("큐레이션을 제목으로 검색할 수 있다")
 	void findCurationByTitle() throws Exception {
 		createCurationWithTitle("ex1");
 		createCurationWithTitle("test-ex");
@@ -230,8 +234,8 @@ public class ApiV1CurationControllerTest {
 			.collect(Collectors.toUnmodifiableList()), member);
 	}
 
-	// 내용으로 글 검색
 	@Test
+	@DisplayName("내용으로 큐레이션을 검색할 수 있다")
 	void findCurationByContent() throws Exception {
 		createCurationWithContent("example");
 		createCurationWithContent("test-example");
@@ -254,8 +258,8 @@ public class ApiV1CurationControllerTest {
 			.collect(Collectors.toUnmodifiableList()), member);
 	}
 
-	// 제목과 내용으로 글 검색
 	@Test
+	@DisplayName("제목과 내용으로 큐레이션을 검색할 수 있다")
 	void findCurationByTitleAndContent() throws Exception {
 		createCurationWithTitleAndContent("popular", "famous1");
 		createCurationWithTitleAndContent("sample", "test-famous");
@@ -278,8 +282,8 @@ public class ApiV1CurationControllerTest {
 			.collect(Collectors.toUnmodifiableList()), member);
 	}
 
-	// 최신순으로 글 조회
 	@Test
+	@DisplayName("최신순으로 큐레이션을 전체 조회할 수 있다")
 	void findCurationByLatest() throws Exception {
 		createCurationWithTitleAndContent("title1", "content1");
 		createCurationWithTitleAndContent("title2", "content2");
@@ -294,8 +298,8 @@ public class ApiV1CurationControllerTest {
 			.andExpect(jsonPath("$.data[2].content").value("content1"));
 	}
 
-	// 오래된순으로 글 조회
 	@Test
+	@DisplayName("오래된 순으로 큐레이션을 전체 조회할 수 있다")
 	void findCurationByOldest() throws Exception {
 		createCurationWithTitleAndContent("title1", "content1");
 		createCurationWithTitleAndContent("title2", "content2");
@@ -310,8 +314,8 @@ public class ApiV1CurationControllerTest {
 			.andExpect(jsonPath("$.data[3].content").value("content3"));
 	}
 
-	// 좋아요순으로 글 조회
 	@Test
+	@DisplayName("좋아요 순으로 큐레이션을 전체 조회할 수 있다")
 	void findCurationByLikeCount() throws Exception {
 		createCurationWithTitleAndContentAndLikeCount("title1", "content1", 4L);
 		createCurationWithTitleAndContentAndLikeCount("title2", "content2", 10L);
@@ -338,11 +342,9 @@ public class ApiV1CurationControllerTest {
 		return curation;
 	}
 
-	// 좋아요 테스트
 	@Test
+	@DisplayName("큐레이션에 좋아요를 할 수 있다")
 	void likeCuration() throws Exception {
-		// 테스트용 데이터 저장
-
 		Curation savedCuration = curationService.createCuration("Test Title", "Test Content",
 			curationReqDTO.getLinkReqDtos()
 				.stream()
@@ -351,8 +353,6 @@ public class ApiV1CurationControllerTest {
 				.stream()
 				.map(tagReqDto -> tagReqDto.getName())
 				.collect(Collectors.toUnmodifiableList()), member);
-
-
 
 		mockMvc.perform(
 				post("/api/v1/curation/{id}", savedCuration.getId())
@@ -365,6 +365,7 @@ public class ApiV1CurationControllerTest {
 	}
 
 	@Test
+	@DisplayName("큐레이션 작성자로 큐레이션을 검색할 수 있다")
 	void findCurationByAuthor() throws Exception {
 		var author1 = createMember("author1");
 		var author2 = createMember("author2");
@@ -400,6 +401,26 @@ public class ApiV1CurationControllerTest {
 		curationRepository.save(curation);
 	}
 
-    @Autowired
-    private AuthTokenService authTokenService;
+	@Test
+	@DisplayName("팔로우중인 큐레이터의 큐레이션을 전체 조회할 수 있다")
+	void followingCuration() throws Exception {
+		Member member = memberRepository.findById(3L).get();
+		String accessToken = authTokenService.genAccessToken(member);
+
+		mockMvc.perform(get("/api/v1/curation/following")
+			.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("200-1"))
+			.andExpect(jsonPath("$.msg").value("팔로우중인 큐레이터의 큐레이션이 조회되었습니다."))
+			.andExpect(jsonPath("$.data.length()").value(1));
+	}
+
+	@Test
+	@DisplayName("실패 - 인증 정보가 없으면 팔로우중인 큐레이션 조회에 실패한다")
+	void followingCuration_noAuth() throws Exception {
+		mockMvc.perform(get("/api/v1/curation/following"))
+			.andExpect(status().isUnauthorized())
+			.andExpect(jsonPath("$.code").value("401-1"))
+			.andExpect(jsonPath("$.msg").value("접근이 거부되었습니다. 로그인 상태를 확인해 주세요."));
+	}
 }

--- a/frontend/project2/app/components/comment-section.tsx
+++ b/frontend/project2/app/components/comment-section.tsx
@@ -5,6 +5,7 @@ import type React from "react";
 import { useEffect, useState } from "react";
 import Image from "next/image";
 import { Heart, Edit, Trash2, X, Check } from "lucide-react";
+import CommentSkeleton from "./skeleton/comment-skeleton";
 
 // 댓글 데이터 타입 정의를 API 응답 구조에 맞게 수정
 type Comment = {
@@ -34,10 +35,12 @@ export default function CommentSection({ postId }: { postId: string }) {
   const [error, setError] = useState<string | null>(null); // 오류 상태
   const [editingCommentId, setEditingCommentId] = useState<number | null>(null); // 수정 중인 댓글 ID
   const [editContent, setEditContent] = useState(""); // 수정 중인 댓글 내용
+  const [loading, setLoading] = useState(true); // 로딩 상태 추가
 
   // API에서 커레이션 데이터를 불러오는 함수 수정
   const fetchCurationData = async (id: string) => {
     try {
+      setLoading(true);
       setError(null);
       const res = await fetch(`http://localhost:8080/api/v1/curation/${id}`);
 
@@ -60,6 +63,11 @@ export default function CommentSection({ postId }: { postId: string }) {
     } catch (error) {
       console.error("API 호출 중 오류 발생:", error);
       setError((error as Error).message);
+    } finally {
+      // 스켈레톤 UI가 잠시 보이도록 약간의 지연 추가 (실제 환경에서는 제거 가능)
+      setTimeout(() => {
+        setLoading(false);
+      }, 500);
     }
   };
 
@@ -271,6 +279,11 @@ export default function CommentSection({ postId }: { postId: string }) {
       return "날짜 형식 오류";
     }
   };
+
+  // 로딩 중일 때 스켈레톤 UI 표시
+  if (loading) {
+    return <CommentSkeleton />;
+  }
 
   return (
     <div className="space-y-6">

--- a/frontend/project2/app/components/post-list.tsx
+++ b/frontend/project2/app/components/post-list.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Heart, MessageSquare, Bookmark, Share2 } from "lucide-react";
-import { ClipLoader } from "react-spinners"; // 로딩 애니메이션
+import CurationSkeleton from "./skeleton/curation-skeleton";
 
 // Curation 데이터 인터페이스 정의
 interface Curation {
@@ -37,7 +37,7 @@ type SortOrder = "LATEST" | "LIKECOUNT";
 export default function PostList() {
   const [curations, setCurations] = useState<Curation[]>([]);
   const [sortOrder, setSortOrder] = useState<SortOrder>("LATEST"); // 기본값: 최신순
-  const [loading, setLoading] = useState<boolean>(false);
+  const [loading, setLoading] = useState<boolean>(true);
   const [linkMetaDataList, setLinkMetaDataList] = useState<{
     [key: number]: LinkMetaData[];
   }>({}); // 각 큐레이션에 대한 메타 데이터 상태 (배열로 수정)
@@ -307,10 +307,12 @@ export default function PostList() {
         </div>
       )}
 
-      {/* 로딩 상태 표시 */}
+      {/* 로딩 상태 표시 - 스켈레톤 UI로 대체 */}
       {loading ? (
-        <div className="flex justify-center items-center py-10">
-          <ClipLoader size={50} color="#3498db" />
+        <div className="space-y-6 pt-4">
+          {[...Array(3)].map((_, index) => (
+            <CurationSkeleton key={index} />
+          ))}
         </div>
       ) : (
         /* 게시글 목록 */
@@ -321,14 +323,9 @@ export default function PostList() {
             curations.map((curation) => (
               <div key={curation.id} className="space-y-4 border-b pb-6">
                 <div className="flex items-center space-x-2">
-                  <p className="text-xs text-gray-500">
-                    {
-                      `작성된 날짜 : ${formatDate(curation.createdAt)}`
-                      /* {Math.floor(new Date(curation.modifiedAt).getTime() / 1000) !== Math.floor(new Date(curation.createdAt).getTime() / 1000)
-                  ? `수정된 날짜 : ${formatDate(curation.modifiedAt)}`
-                  : `작성된 날짜 : ${formatDate(curation.createdAt)}`} */
-                    }
-                  </p>
+                  <p className="text-xs text-gray-500">{`작성된 날짜 : ${formatDate(
+                    curation.createdAt
+                  )}`}</p>
                 </div>
 
                 <div>
@@ -370,7 +367,7 @@ export default function PostList() {
                     <div className="mt-4 rounded-lg border p-4 cursor-pointer">
                       <div className="flex items-center space-x-3">
                         <img
-                          src={metaData.image}
+                          src={metaData.image || "/placeholder.svg"}
                           alt="Preview"
                           className="h-12 w-12 rounded-lg"
                         />

--- a/frontend/project2/app/components/post-list.tsx
+++ b/frontend/project2/app/components/post-list.tsx
@@ -347,7 +347,6 @@ export default function PostList() {
                   </button>
                 </div>
 
-
                 {/* 태그 표시 */}
                 <div className="flex space-x-2 mt-2">
                   {curation.tags.map((tag) => (

--- a/frontend/project2/app/components/skeleton/comment-skeleton.tsx
+++ b/frontend/project2/app/components/skeleton/comment-skeleton.tsx
@@ -1,0 +1,36 @@
+export default function CommentSkeleton() {
+  return (
+    <div className="space-y-6 animate-pulse">
+      <div className="h-7 w-32 bg-gray-200 rounded"></div>
+
+      {/* 댓글 입력 폼 스켈레톤 */}
+      <div className="space-y-3">
+        <div className="h-24 w-full bg-gray-200 rounded-md"></div>
+        <div className="flex justify-end">
+          <div className="h-9 w-24 bg-gray-200 rounded-md"></div>
+        </div>
+      </div>
+
+      {/* 댓글 목록 스켈레톤 */}
+      <div className="space-y-4 mt-6">
+        {[...Array(3)].map((_, index) => (
+          <div key={index} className="rounded-lg border p-4">
+            <div className="flex justify-between">
+              <div className="flex items-center space-x-2">
+                <div className="h-9 w-9 bg-gray-200 rounded-full"></div>
+                <div>
+                  <div className="h-5 w-24 bg-gray-200 rounded"></div>
+                  <div className="h-3 w-32 bg-gray-200 rounded mt-1"></div>
+                </div>
+              </div>
+            </div>
+            <div className="mt-2 space-y-2">
+              <div className="h-4 w-full bg-gray-200 rounded"></div>
+              <div className="h-4 w-3/4 bg-gray-200 rounded"></div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/project2/app/components/skeleton/curation-detail.tsx
+++ b/frontend/project2/app/components/skeleton/curation-detail.tsx
@@ -1,0 +1,107 @@
+export default function CurationDetailSkeleton() {
+  return (
+    <div className="space-y-6 animate-pulse">
+      {/* 작성자 정보 스켈레톤 */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center space-x-2">
+          <div className="h-10 w-10 bg-gray-200 rounded-full"></div>
+          <div>
+            <div className="h-5 w-24 bg-gray-200 rounded"></div>
+            <div className="h-3 w-32 bg-gray-200 rounded mt-1"></div>
+          </div>
+        </div>
+        <div className="h-8 w-20 bg-gray-200 rounded-md"></div>
+      </div>
+
+      {/* 제목 스켈레톤 */}
+      <div className="h-9 w-3/4 bg-gray-200 rounded"></div>
+
+      {/* 링크 카드 섹션 스켈레톤 */}
+      <div className="my-6 space-y-4">
+        <div className="h-7 w-40 bg-gray-200 rounded"></div>
+
+        {/* 링크 카드 스켈레톤 */}
+        <div className="rounded-lg border shadow-sm overflow-hidden">
+          <div className="bg-gray-50 p-6">
+            <div className="flex flex-col sm:flex-row items-start sm:items-center">
+              <div className="mr-0 sm:mr-4 mb-4 sm:mb-0 flex-shrink-0">
+                <div className="h-20 w-20 bg-gray-200 rounded-md"></div>
+              </div>
+              <div className="flex-1 space-y-2">
+                <div className="h-6 w-3/4 bg-gray-200 rounded"></div>
+                <div className="h-4 w-full bg-gray-200 rounded"></div>
+                <div className="h-4 w-1/2 bg-gray-200 rounded"></div>
+                <div className="flex items-center">
+                  <div className="h-4 w-32 bg-gray-200 rounded"></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 태그 스켈레톤 */}
+      <div className="flex flex-wrap gap-2">
+        <div className="h-6 w-16 bg-gray-200 rounded-full"></div>
+        <div className="h-6 w-20 bg-gray-200 rounded-full"></div>
+        <div className="h-6 w-14 bg-gray-200 rounded-full"></div>
+      </div>
+
+      {/* 본문 내용 스켈레톤 */}
+      <div className="space-y-3">
+        <div className="h-4 w-full bg-gray-200 rounded"></div>
+        <div className="h-4 w-full bg-gray-200 rounded"></div>
+        <div className="h-4 w-full bg-gray-200 rounded"></div>
+        <div className="h-4 w-3/4 bg-gray-200 rounded"></div>
+        <div className="h-4 w-full bg-gray-200 rounded"></div>
+        <div className="h-4 w-5/6 bg-gray-200 rounded"></div>
+      </div>
+
+      {/* 액션 버튼 스켈레톤 */}
+      <div className="flex items-center justify-between border-t border-b py-4">
+        <div className="flex items-center space-x-4">
+          <div className="h-6 w-16 bg-gray-200 rounded"></div>
+          <div className="h-6 w-16 bg-gray-200 rounded"></div>
+        </div>
+        <div className="flex space-x-2">
+          <div className="h-9 w-9 bg-gray-200 rounded-md"></div>
+          <div className="h-9 w-9 bg-gray-200 rounded-md"></div>
+        </div>
+      </div>
+
+      {/* 댓글 섹션 스켈레톤 */}
+      <div className="space-y-4">
+        <div className="h-7 w-32 bg-gray-200 rounded"></div>
+
+        {/* 댓글 입력 폼 스켈레톤 */}
+        <div className="space-y-3">
+          <div className="h-24 w-full bg-gray-200 rounded-md"></div>
+          <div className="flex justify-end">
+            <div className="h-9 w-24 bg-gray-200 rounded-md"></div>
+          </div>
+        </div>
+
+        {/* 댓글 목록 스켈레톤 */}
+        <div className="space-y-4 mt-6">
+          {[...Array(2)].map((_, index) => (
+            <div key={index} className="rounded-lg border p-4">
+              <div className="flex justify-between">
+                <div className="flex items-center space-x-2">
+                  <div className="h-9 w-9 bg-gray-200 rounded-full"></div>
+                  <div>
+                    <div className="h-5 w-24 bg-gray-200 rounded"></div>
+                    <div className="h-3 w-32 bg-gray-200 rounded mt-1"></div>
+                  </div>
+                </div>
+              </div>
+              <div className="mt-2 space-y-2">
+                <div className="h-4 w-full bg-gray-200 rounded"></div>
+                <div className="h-4 w-3/4 bg-gray-200 rounded"></div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/project2/app/components/skeleton/curation-skeleton.tsx
+++ b/frontend/project2/app/components/skeleton/curation-skeleton.tsx
@@ -1,0 +1,51 @@
+export default function CurationSkeleton() { return (
+<div className="space-y-4 border-b pb-6 animate-pulse">
+  {/* 날짜 스켈레톤 */}
+  <div className="flex items-center space-x-2">
+    <div className="h-4 w-32 bg-gray-200 rounded"></div>
+  </div>
+
+  {/* 제목 스켈레톤 */}
+  <div className="h-7 w-3/4 bg-gray-200 rounded"></div>
+
+  {/* 내용 스켈레톤 */}
+  <div className="space-y-2">
+    <div className="h-4 w-full bg-gray-200 rounded"></div>
+    <div className="h-4 w-full bg-gray-200 rounded"></div>
+    <div className="h-4 w-2/3 bg-gray-200 rounded"></div>
+  </div>
+
+  {/* 더보기 버튼 스켈레톤 */}
+  <div className="h-5 w-16 bg-gray-200 rounded"></div>
+
+  {/* 태그 스켈레톤 */}
+  <div className="flex space-x-2">
+    <div className="h-6 w-16 bg-gray-200 rounded-full"></div>
+    <div className="h-6 w-20 bg-gray-200 rounded-full"></div>
+    <div className="h-6 w-14 bg-gray-200 rounded-full"></div>
+  </div>
+
+  {/* 링크 메타데이터 카드 스켈레톤 */}
+  <div className="mt-4 rounded-lg border p-4">
+    <div className="flex items-center space-x-3">
+      <div className="h-12 w-12 bg-gray-200 rounded-lg"></div>
+      <div className="space-y-2 flex-1">
+        <div className="h-5 w-3/4 bg-gray-200 rounded"></div>
+        <div className="h-4 w-full bg-gray-200 rounded"></div>
+      </div>
+    </div>
+  </div>
+
+  {/* 액션 버튼 스켈레톤 */}
+  <div className="flex items-center justify-between">
+    <div className="flex items-center space-x-4">
+      <div className="h-5 w-16 bg-gray-200 rounded"></div>
+      <div className="h-5 w-16 bg-gray-200 rounded"></div>
+    </div>
+    <div className="flex space-x-2">
+      <div className="h-5 w-5 bg-gray-200 rounded"></div>
+      <div className="h-5 w-5 bg-gray-200 rounded"></div>
+    </div>
+  </div>
+</div>
+) }

--- a/frontend/project2/app/components/skeleton/sidebar-skeleton.tsx
+++ b/frontend/project2/app/components/skeleton/sidebar-skeleton.tsx
@@ -1,0 +1,34 @@
+export default function SidebarSkeleton() {
+  return (
+    <div className="space-y-6 animate-pulse">
+      {/* 인기 큐레이션 스켈레톤 */}
+      <div className="rounded-lg border p-4">
+        <div className="h-6 w-40 bg-gray-200 rounded mb-4"></div>
+        <div className="space-y-4">
+          {[...Array(3)].map((_, index) => (
+            <div key={index} className="space-y-1">
+              <div className="flex items-center">
+                <div className="mr-2 h-6 w-6 bg-gray-200 rounded-full"></div>
+                <div className="h-5 w-40 bg-gray-200 rounded"></div>
+              </div>
+              <div className="pl-8 h-3 w-32 bg-gray-200 rounded"></div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* 작성자 정보 스켈레톤 */}
+      <div className="rounded-lg border p-4">
+        <div className="h-6 w-32 bg-gray-200 rounded mb-3"></div>
+        <div className="flex items-center space-x-3">
+          <div className="h-12 w-12 bg-gray-200 rounded-full"></div>
+          <div>
+            <div className="h-5 w-24 bg-gray-200 rounded"></div>
+            <div className="h-3 w-32 bg-gray-200 rounded mt-1"></div>
+          </div>
+        </div>
+        <div className="mt-3 h-8 w-full bg-gray-200 rounded-md"></div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/project2/app/curation/following/page.tsx
+++ b/frontend/project2/app/curation/following/page.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Heart, MessageSquare, Bookmark, Share2 } from "lucide-react";
+import { ClipLoader } from "react-spinners";
+
+// Curation 데이터 인터페이스 정의
+interface Curation {
+  id: number;
+  title: string;
+  content: string;
+  createdAt: string;
+  modifiedAt: string;
+  likeCount: number;
+  urls: { url: string }[];
+  tags: { name: string }[];
+}
+
+// Link 메타 데이터 인터페이스 정의
+interface LinkMetaData {
+  url: string;
+  title: string;
+  description: string;
+  image: string;
+}
+
+export default function FollowingCurations() {
+  const [curations, setCurations] = useState<Curation[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const [linkMetaDataList, setLinkMetaDataList] = useState<{
+    [key: number]: LinkMetaData[];
+  }>({});
+
+  // API 요청 함수
+  const fetchFollowingCurations = async () => {
+    try {
+      setLoading(true);
+      const response = await fetch(
+        "http://localhost:8080/api/v1/curation/following"
+      );
+      if (!response.ok) {
+        throw new Error(
+          "팔로우 중인 큐레이터의 큐레이션을 불러오지 못했습니다."
+        );
+      }
+
+      const data = await response.json();
+      if (data && data.data) {
+        setCurations(data.data);
+      } else {
+        console.error("No data found in the response");
+        setCurations([]);
+      }
+    } catch (error) {
+      console.error("Error fetching following curations:", error);
+      setError((error as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // 메타 데이터 추출 함수
+  const fetchLinkMetaData = async (url: string, curationId: number) => {
+    try {
+      const response = await fetch(
+        `http://localhost:8080/api/v1/link/preview`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ url: url }),
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error("Failed to fetch link metadata");
+      }
+
+      const data = await response.json();
+      setLinkMetaDataList((prev) => {
+        const existingMetaData = prev[curationId] || [];
+        const newMetaData = existingMetaData.filter(
+          (meta) => meta.url !== data.data.url
+        );
+        return {
+          ...prev,
+          [curationId]: [...newMetaData, data.data],
+        };
+      });
+    } catch (error) {
+      console.error("Error fetching link metadata:", error);
+    }
+  };
+
+  // 큐레이션마다 메타 데이터 추출
+  useEffect(() => {
+    curations.forEach((curation) => {
+      if (curation.urls && curation.urls.length > 0) {
+        curation.urls.forEach((urlObj) => {
+          if (
+            !linkMetaDataList[curation.id]?.some(
+              (meta) => meta.url === urlObj.url
+            )
+          ) {
+            fetchLinkMetaData(urlObj.url, curation.id);
+          }
+        });
+      }
+    });
+  }, [curations, linkMetaDataList]);
+
+  // 좋아요 추가 API 호출 함수
+  const likeCuration = async (id: number) => {
+    try {
+      const response = await fetch(
+        `http://localhost:8080/api/v1/curation/${id}`,
+        {
+          method: "POST",
+        }
+      );
+      if (!response.ok) {
+        throw new Error("Failed to like the post");
+      }
+
+      // 좋아요를 추가한 후, 데이터를 다시 불러와서 화면 갱신
+      fetchFollowingCurations();
+    } catch (error) {
+      console.error("Error liking the post:", error);
+    }
+  };
+
+  // 날짜 형식화 함수
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    const hours = String(date.getHours()).padStart(2, "0");
+    const minutes = String(date.getMinutes()).padStart(2, "0");
+    return `${year}년 ${month}월 ${day}일 ${hours}:${minutes}`;
+  };
+
+  useEffect(() => {
+    fetchFollowingCurations();
+  }, []);
+
+  return (
+    <>
+      {/* 로딩 상태 표시 */}
+      {loading ? (
+        <div className="flex justify-center items-center py-10">
+          <ClipLoader size={50} color="#3498db" />
+        </div>
+      ) : (
+        /* 게시글 목록 */
+        <div className="space-y-6 pt-4">
+          {curations.length === 0 ? (
+            <p>팔로우 중인 큐레이터의 글이 없습니다.</p>
+          ) : (
+            curations.map((curation) => (
+              <div key={curation.id} className="space-y-4 border-b pb-6">
+                <div className="flex items-center space-x-2">
+                  <p className="text-xs text-gray-500">{`작성된 날짜 : ${formatDate(
+                    curation.createdAt
+                  )}`}</p>
+                </div>
+
+                <div>
+                  <Link href={`/curation/${curation.id}`} className="group">
+                    <h2 className="text-xl font-bold group-hover:text-blue-600">
+                      {curation.title}
+                    </h2>
+                  </Link>
+                  <p className="mt-2 text-gray-600">
+                    {curation.content.length > 100
+                      ? `${curation.content.substring(0, 100)}...`
+                      : curation.content}
+                  </p>
+                  <button className="mt-2 text-sm font-medium text-blue-600">
+                    더보기
+                  </button>
+                </div>
+
+                {/* 태그 표시 */}
+                <div className="flex space-x-2 mt-2">
+                  {curation.tags.map((tag, index) => (
+                    <span
+                      key={`${tag.name}-${index}`}
+                      className="px-3 py-1 text-sm font-medium rounded-full bg-gray-200 text-gray-600"
+                    >
+                      {tag.name}
+                    </span>
+                  ))}
+                </div>
+
+                {/* 메타 데이터 카드 */}
+                {linkMetaDataList[curation.id]?.map((metaData, index) => (
+                  <Link key={index} href={metaData.url} passHref>
+                    <div className="mt-4 rounded-lg border p-4 cursor-pointer">
+                      <div className="flex items-center space-x-3">
+                        <img
+                          src={metaData.image || "/placeholder.svg"}
+                          alt="Preview"
+                          className="h-12 w-12 rounded-lg"
+                        />
+                        <div>
+                          <h3 className="font-medium">{metaData.title}</h3>
+                          <p className="text-sm text-gray-600">
+                            {metaData.description}
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+                  </Link>
+                ))}
+
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center space-x-4">
+                    <button
+                      className="flex items-center space-x-1 text-sm text-gray-500"
+                      onClick={() => likeCuration(curation.id)}
+                    >
+                      <Heart className="h-4 w-4" />
+                      <span>{curation.likeCount}</span>
+                    </button>
+                    <button className="flex items-center space-x-1 text-sm text-gray-500">
+                      <MessageSquare className="h-4 w-4" />
+                      <span>12</span>
+                    </button>
+                  </div>
+                  <div className="flex space-x-2">
+                    <button>
+                      <Bookmark className="h-4 w-4 text-gray-500" />
+                    </button>
+                    <button>
+                      <Share2 className="h-4 w-4 text-gray-500" />
+                    </button>
+                  </div>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/project2/app/curation/following/page.tsx
+++ b/frontend/project2/app/curation/following/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Heart, MessageSquare, Bookmark, Share2 } from "lucide-react";
-import { ClipLoader } from "react-spinners";
+import CurationSkeleton from "@/app/components/skeleton/curation-skeleton";
 
 // Curation 데이터 인터페이스 정의
 interface Curation {
@@ -57,7 +57,10 @@ export default function FollowingCurations() {
       console.error("Error fetching following curations:", error);
       setError((error as Error).message);
     } finally {
-      setLoading(false);
+      // 스켈레톤 UI가 잠시 보이도록 약간의 지연 추가 (실제 환경에서는 제거 가능)
+      setTimeout(() => {
+        setLoading(false);
+      }, 500);
     }
   };
 
@@ -149,10 +152,12 @@ export default function FollowingCurations() {
 
   return (
     <>
-      {/* 로딩 상태 표시 */}
+      {/* 로딩 상태 표시 - 스켈레톤 UI로 대체 */}
       {loading ? (
-        <div className="flex justify-center items-center py-10">
-          <ClipLoader size={50} color="#3498db" />
+        <div className="space-y-6 pt-4">
+          {[...Array(3)].map((_, index) => (
+            <CurationSkeleton key={index} />
+          ))}
         </div>
       ) : (
         /* 게시글 목록 */
@@ -202,7 +207,10 @@ export default function FollowingCurations() {
                     <div className="mt-4 rounded-lg border p-4 cursor-pointer">
                       <div className="flex items-center space-x-3">
                         <img
-                          src={metaData.image || "/placeholder.svg"}
+                          src={
+                            metaData.image ||
+                            "/placeholder.svg?height=48&width=48"
+                          }
                           alt="Preview"
                           className="h-12 w-12 rounded-lg"
                         />

--- a/frontend/project2/app/page.tsx
+++ b/frontend/project2/app/page.tsx
@@ -1,6 +1,8 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import LeftSidebar from "./components/left-sidebar";
 import PostList from "./components/post-list";
 import RightSidebar from "./components/right-sidebar";
+import FollowingCurations from "./curation/following/page";
 
 export default function Home() {
   return (
@@ -9,7 +11,22 @@ export default function Home() {
         <LeftSidebar />
       </div>
       <div className="col-span-7">
-        <PostList />
+        <Tabs defaultValue="latest" className="w-full">
+          <TabsList className="mb-4 w-full">
+            <TabsTrigger value="latest" className="flex-1">
+              최신
+            </TabsTrigger>
+            <TabsTrigger value="following" className="flex-1">
+              팔로잉
+            </TabsTrigger>
+          </TabsList>
+          <TabsContent value="latest">
+            <PostList />
+          </TabsContent>
+          <TabsContent value="following">
+            <FollowingCurations />
+          </TabsContent>
+        </Tabs>
       </div>
       <div className="col-span-3">
         <RightSidebar />

--- a/frontend/project2/components/ui/tabs.tsx
+++ b/frontend/project2/components/ui/tabs.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import * as TabsPrimitive from "@radix-ui/react-tabs";
+
 import { cn } from "@/libs/utils";
 
 const Tabs = TabsPrimitive.Root;
@@ -13,7 +14,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground",
+      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
       className
     )}
     {...props}
@@ -28,7 +29,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow",
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
       className
     )}
     {...props}


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 팔로우중인 큐레이터의 큐레이션 조회 기능 구현
- 팔로우중인 큐레이터의 큐레이션 페이지 구현 및 연결
- 큐레이션 목록, 큐레이션 상세 페이지에 스켈레톤 로딩을 적용해 깜빡거림 개선

<img width="1186" alt="스크린샷 2025-03-11 오후 12 17 31" src="https://github.com/user-attachments/assets/f5247bf5-a340-42ea-aece-f5e2afa43b48" />

## 고려사항
로그인 구현되지 않아 프론트 테스트는 Controller에서 이미 존재하는 member를 받도록 임시로 수정해야 확인 가능

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

Closes #92 
