### PR TITLE
fix: 오늘의 인기 큐레이션 오류 수정

### DIFF
--- a/backend/project2/src/main/java/com/team8/project2/domain/curation/curation/controller/ApiV1CurationController.java
+++ b/backend/project2/src/main/java/com/team8/project2/domain/curation/curation/controller/ApiV1CurationController.java
@@ -203,5 +203,4 @@ public class ApiV1CurationController {
         TrendingCurationResDto trendingCurationResDto = curationService.getTrendingCuration();
         return new RsData<>("200-1", "트렌딩 큐레이션이 조회되었습니다.", trendingCurationResDto);
     }
-
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
오늘의 인기 큐레이션에서 삭제된 글이 있으면 응답에 실패하는 오류 해결
글 삭제 시 Redis 정보도 삭제하고, 오늘의 인기 큐레이션 조회 시 글이 존재하지 않으면 제외하도록 수정

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

Closes #148 
